### PR TITLE
Python CI: matrix tests with combined checks

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,53 +7,45 @@ on:
       - "python/**"
       - ".github/workflows/python.yml"
   pull_request:
-    branches: [ main, master ]
+    branches:
+      - main
     paths:
       - "python/**"
       - ".github/workflows/python.yml"
   workflow_dispatch:
 
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.14"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Install dependencies
-        working-directory: python
-        run: uv sync --group dev
-
-      - name: Run lint and type checks
-        working-directory: python
-        run: make check
-
   test:
     name: Test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
+        id: setup-python
         with:
-          python-version: "3.14"
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v1
         with:
           version: "0.8.5"
 
       - name: Install dependencies
-        working-directory: python
-        run: uv sync --frozen --group dev
+        env:
+          UV_PYTHON: ${{ steps.setup-python.outputs.python-path }}
+        run: uv sync --frozen --all-extras --project python
+
+      - name: Run checks
+        env:
+          UV_PYTHON: ${{ steps.setup-python.outputs.python-path }}
+        run: make -C python check
 
       - name: Run tests
-        working-directory: python
-        run: make test
+        env:
+          UV_PYTHON: ${{ steps.setup-python.outputs.python-path }}
+        run: make -C python test


### PR DESCRIPTION
- Run checks and tests in a single job across Python 3.12/3.13/3.14
- Pin uv setup and use uv sync --frozen --all-extras --project python with UV_PYTHON
- Keep prerelease support for 3.14 in setup-python