### PR TITLE
feat(go): add Prompt function for simplified single-turn conversation

### DIFF
--- a/go/prompt.go
+++ b/go/prompt.go
@@ -1,0 +1,26 @@
+package kimi
+
+import (
+	"context"
+	"runtime"
+
+	"github.com/MoonshotAI/kimi-agent-sdk/go/wire"
+)
+
+func Prompt(ctx context.Context, content wire.Content, options ...Option) (*Turn, error) {
+	session, err := NewSession(options...)
+	if err != nil {
+		return nil, err
+	}
+	cleanup := func(s *Session) {
+		s.Close() //nolint:errcheck
+	}
+	runtime.AddCleanup(session, cleanup, session)
+	turn, err := session.Prompt(ctx, content)
+	if err != nil {
+		return nil, err
+	}
+	turn.ref = session
+	runtime.KeepAlive(session)
+	return turn, nil
+}

--- a/go/turn.go
+++ b/go/turn.go
@@ -61,6 +61,10 @@ type Turn struct {
 	usage atomic.Pointer[Usage]
 
 	wireRequestResponseChan chan<- wire.RequestResponse
+
+	// ref holds a reference to prevent the referenced object from being
+	// garbage collected while this Turn is still in use.
+	ref any
 }
 
 func (t *Turn) watch(parent context.Context) {


### PR DESCRIPTION
Add a standalone Prompt function that simplifies one-shot API calls by automatically managing session lifecycle with runtime.AddCleanup.