### PR TITLE
docs(python): add module-level docstrings to public modules

### DIFF
--- a/python/src/kimi_agent_sdk/__init__.py
+++ b/python/src/kimi_agent_sdk/__init__.py
@@ -1,3 +1,65 @@
+"""
+Kimi Agent SDK is a Python SDK for building AI agents powered by Kimi.
+It provides both high-level and low-level APIs for seamless agent integration, stateful sessions,
+and tool orchestration in modern AI applications.
+
+Key features:
+
+- `kimi_agent_sdk.prompt` provides a high-level async generator API that sends prompts to Kimi
+  and yields aggregated Message objects, handling approval requests automatically or via custom
+  handlers.
+- `kimi_agent_sdk.Session` offers low-level control with Wire message access, manual approval
+  handling, session persistence, and context management for long-running agent interactions.
+- Message structures, approval types, and exceptions are re-exported from kosong and kimi_cli
+  for convenient access.
+
+Example (high-level API):
+
+```python
+import asyncio
+
+from kimi_agent_sdk import prompt
+
+
+async def main() -> None:
+    async for message in prompt(
+        "What is the capital of France?",
+        model="kimi",
+        yolo=True,
+    ):
+        print(message.extract_text())
+
+
+asyncio.run(main())
+```
+
+Example (low-level API with Session):
+
+```python
+import asyncio
+
+from kaos.path import KaosPath
+
+from kimi_agent_sdk import ApprovalRequest, Session
+
+
+async def main() -> None:
+    async with await Session.create(
+        work_dir=KaosPath.cwd(),
+        model="kimi",
+        yolo=False,
+    ) as session:
+        async for wire_msg in session.prompt("What is the capital of France?"):
+            if isinstance(wire_msg, ApprovalRequest):
+                wire_msg.resolve("approve")
+            else:
+                print(wire_msg)
+
+
+asyncio.run(main())
+```
+"""
+
 from __future__ import annotations
 
 from fastmcp.mcp_config import MCPConfig


### PR DESCRIPTION
Add module-level docstrings to all Python SDK modules following, with clear descriptions, key features, and runnable examples