### PR TITLE
fix(node): align license declaration with project (Apache-2.0)

### DIFF
--- a/node/agent_sdk/package.json
+++ b/node/agent_sdk/package.json
@@ -2,7 +2,7 @@
   "name": "@moonshot-ai/kimi-agent-sdk",
   "version": "0.0.8",
   "description": "SDK for interacting with Kimi Code CLI",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/MoonshotAI/kimi-agent-sdk.git",


### PR DESCRIPTION
## Summary
- Fixed license inconsistency in Node.js SDK package.json

## Problem
The Node.js SDK (`node/agent_sdk/package.json`) declared `"license": "MIT"`, but the project uses Apache-2.0 (as seen in the root LICENSE file and Python SDK's `pyproject.toml`).

## Solution
Changed the license field in `node/agent_sdk/package.json` from `"MIT"` to `"Apache-2.0"` to ensure consistency across all SDK packages.

## Impact
- No code changes, only metadata correction
- Ensures legal clarity across all published packages
- Aligns with the project's Apache-2.0 license

🤖 Generated with [Claude Code](https://claude.com/claude-code)