### PR TITLE
feat(vscode): add configurable editor context sharing modes

### DIFF
--- a/node/vscode_extension/package.json
+++ b/node/vscode_extension/package.json
@@ -3,7 +3,7 @@
   "publisher": "moonshot-ai",
   "displayName": "Kimi Code (Technical Preview)",
   "description": "Official Kimi Code plugin for VS Code",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -86,6 +86,17 @@
           "type": "boolean",
           "default": false,
           "description": "Auto-expand thinking/reasoning sections so you can see the AI's thought process in real-time"
+        },
+        "kimi.editorContext": {
+          "type": "string",
+          "default": "never",
+          "enum": ["never", "onConversationStart", "onFileChange"],
+          "enumDescriptions": [
+            "Never share editor context",
+            "Share once when conversation starts",
+            "Share when active file changes"
+          ],
+          "description": "Control when to share the active editor's file and cursor position with Kimi"
         }
       }
     },

--- a/node/vscode_extension/src/config/vscode-settings.ts
+++ b/node/vscode_extension/src/config/vscode-settings.ts
@@ -37,6 +37,10 @@ export const VSCodeSettings = {
     return getConfig().get<boolean>("alwaysExpandThinking", false);
   },
 
+  get editorContext(): "never" | "onConversationStart" | "onFileChange" {
+    return getConfig().get<"never" | "onConversationStart" | "onFileChange">("editorContext", "never");
+  },
+
   getExtensionConfig(): ExtensionConfig {
     return {
       executablePath: this.executablePath,
@@ -56,7 +60,7 @@ export function onSettingsChange(callback: (changedKeys: string[]) => void): vsc
     if (!e.affectsConfiguration("kimi")) {
       return;
     }
-    const keys = ["yoloMode", "autosave", "executablePath", "enableNewConversationShortcut", "useCtrlEnterToSend", "environmentVariables", "alwaysExpandThinking"];
+    const keys = ["yoloMode", "autosave", "executablePath", "enableNewConversationShortcut", "useCtrlEnterToSend", "environmentVariables", "alwaysExpandThinking", "editorContext"];
     const changedKeys = keys.filter((key) => e.affectsConfiguration(`kimi.${key}`));
     if (changedKeys.length > 0) {
       callback(changedKeys);


### PR DESCRIPTION
## Summary

Add a new setting `kimi.editorContext` to control when the active editor's file and cursor position are shared with Kimi.

## Changes

- Add `kimi.editorContext` setting with three modes:
  - `never` (default): Never share editor context
  - `onConversationStart`: Share once when a new conversation starts
  - `onFileChange`: Share when the active file changes during conversation

- Improve system context injection logic:
  - Track injected context per session to avoid redundant injections
  - Simplify context format: `file.ts:42 (L10-20 selected), unsaved`
  - Clean up session tracking on conversation reset

- Bump version to 0.4.1

## Related

Addresses user feedback about context injection behavior.