### PR TITLE
refactor(sdk): rename SubagentEvent.task_tool_call_id to parent_tool_call_id

### DIFF
--- a/node/agent_sdk/README.md
+++ b/node/agent_sdk/README.md
@@ -452,8 +452,8 @@ for await (const event of turn) {
 ```typescript
 for await (const event of turn) {
   if (event.type === 'SubagentEvent') {
-    const { task_tool_call_id, event: subEvent } = event.payload;
-    console.log(`Subagent ${task_tool_call_id}: ${subEvent.type}`);
+    const { parent_tool_call_id, event: subEvent } = event.payload;
+    console.log(`Subagent ${parent_tool_call_id}: ${subEvent.type}`);
   }
 }
 ```

--- a/node/agent_sdk/schema.ts
+++ b/node/agent_sdk/schema.ts
@@ -518,7 +518,7 @@ export interface ParseErrorPayload {
 
 // Sub-agent event
 export interface SubagentEvent {
-  task_tool_call_id: string;
+  parent_tool_call_id: string;
   event: WireEvent;
 }
 
@@ -614,7 +614,7 @@ function parseWireEvent(raw: { type: string; payload?: unknown }): WireEvent {
 
 export const SubagentEventSchema = z.lazy(() =>
   z.object({
-    task_tool_call_id: z.string(),
+    parent_tool_call_id: z.string(),
     event: z.object({ type: z.string(), payload: z.unknown() }).transform(parseWireEvent),
   }),
 ) as z.ZodType<SubagentEvent, z.ZodTypeDef, unknown>;

--- a/node/agent_sdk/tests/schema.test.ts
+++ b/node/agent_sdk/tests/schema.test.ts
@@ -608,7 +608,7 @@ describe("parseRequestPayload", () => {
 describe("SubagentEvent parsing", () => {
   it("parses nested SubagentEvent via parseEventPayload", () => {
     const result = parseEventPayload("SubagentEvent", {
-      task_tool_call_id: "task-1",
+      parent_tool_call_id: "task-1",
       event: {
         type: "ContentPart",
         payload: { type: "text", text: "from subagent" },
@@ -616,7 +616,7 @@ describe("SubagentEvent parsing", () => {
     });
     expect(result.ok).toBe(true);
     if (result.ok && result.value.type === "SubagentEvent") {
-      expect(result.value.payload.task_tool_call_id).toBe("task-1");
+      expect(result.value.payload.parent_tool_call_id).toBe("task-1");
       expect(result.value.payload.event.type).toBe("ContentPart");
     }
   });

--- a/node/agent_sdk/tests/session.test.ts
+++ b/node/agent_sdk/tests/session.test.ts
@@ -1325,7 +1325,7 @@ describe("Edge cases and error handling", () => {
       {
         type: "SubagentEvent",
         payload: {
-          task_tool_call_id: "task-1",
+          parent_tool_call_id: "task-1",
           event: {
             type: "ContentPart",
             payload: { type: "text", text: "From subagent" },

--- a/node/vscode_extension/package.json
+++ b/node/vscode_extension/package.json
@@ -3,7 +3,7 @@
   "publisher": "moonshot-ai",
   "displayName": "Kimi Code",
   "description": "Official Kimi Code plugin for VS Code",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/node/vscode_extension/src/managers/cli.manager.ts
+++ b/node/vscode_extension/src/managers/cli.manager.ts
@@ -71,8 +71,13 @@ export class CLIManager {
   async checkInstalled(workDir: string): Promise<CLICheckResult> {
     const resolved = { isCustomPath: this.isCustomPath(), path: this.getExecutablePath() };
 
-    if (!(await this.ensureCLI())) {
-      return { ok: false, resolved, error: { type: "extract_failed", message: "Failed to install CLI" } };
+    try {
+      if (!(await this.ensureCLI())) {
+        return { ok: false, resolved, error: { type: "extract_failed", message: "Failed to install CLI" } };
+      }
+    } catch (err) {
+      console.error("Error ensuring CLI:", err);
+      return { ok: false, resolved, error: { type: "extract_failed", message: String(err) } };
     }
 
     return this.verify(workDir, resolved);
@@ -106,7 +111,11 @@ export class CLIManager {
       if (manifest.bundledPlatform === platform) {
         console.log(`[Kimi Code] Extracting bundled CLI for ${platform}...`);
         const archiveExt = asset.filename.endsWith(".zip") ? "zip" : "tar.gz";
+
+        console.log(`[Kimi Code] Extracting bundled CLI for ${platform} from ${this.extensionBinPath} with archive type ${archiveExt}...`);
         extractBundledCLI(path.join(this.extensionBinPath, `archive.${archiveExt}`), this.kimiPath);
+        console.log(`[Kimi Code] Bundled CLI extracted for ${platform}`);
+
       } else {
         console.log(`[Kimi Code] Platform ${platform} not matched bundled, downloading CLI...`);
         vscode.window.showInformationMessage(`Downloading Kimi CLI for ${platform}...`);
@@ -134,13 +143,16 @@ export class CLIManager {
       cliVersion = info.kimi_cli_version;
       wireVersion = info.wire_protocol_version;
     } catch (err) {
+      console.error("Error getting CLI info:", err);
       return { ok: false, resolved, error: { type: "not_found", message: String(err) } };
     }
 
     if (compareVersion(cliVersion, MIN_CLI_VERSION) < 0) {
+      console.error(`CLI version too low: ${cliVersion} < ${MIN_CLI_VERSION}`);
       return { ok: false, resolved, error: { type: "version_low", message: `CLI ${cliVersion} < ${MIN_CLI_VERSION}` } };
     }
     if (compareVersion(wireVersion, MIN_WIRE_VERSION) < 0) {
+      console.error(`Wire protocol version too low: ${wireVersion} < ${MIN_WIRE_VERSION}`);
       return { ok: false, resolved, error: { type: "version_low", message: `Wire ${wireVersion} < ${MIN_WIRE_VERSION}` } };
     }
 
@@ -148,6 +160,7 @@ export class CLIManager {
       const initResult = await this.verifyWire(execPath, workDir);
       return { ok: true, resolved, slashCommands: initResult.slash_commands };
     } catch (err) {
+      console.error("Error verifying wire protocol:", err);
       return { ok: false, resolved, error: { type: "protocol_error", message: String(err) } };
     }
   }

--- a/node/vscode_extension/webview-ui/src/stores/event-handlers.ts
+++ b/node/vscode_extension/webview-ui/src/stores/event-handlers.ts
@@ -66,14 +66,14 @@ function resolveSubagentTarget(
   steps: UIStep[],
   payload: SubagentEvent,
 ): { steps: UIStep[]; event: { type: string; payload: any }; toolItem: UIStepItem & { type: "tool_use" } } | null {
-  const { task_tool_call_id, event } = payload;
+  const { parent_tool_call_id, event } = payload;
 
   // Nested SubagentEvent
   if (event.type === "SubagentEvent") {
     return resolveSubagentTarget(steps, event.payload as SubagentEvent);
   }
 
-  const toolItem = findToolUseItem(steps, task_tool_call_id);
+  const toolItem = findToolUseItem(steps, parent_tool_call_id);
   if (!toolItem) {
     return null;
   }


### PR DESCRIPTION
## Summary
- Rename `SubagentEvent.task_tool_call_id` to `parent_tool_call_id` across schema, tests, README, and webview consumer
- Add error logging around CLI install and verification in the VS Code extension
- Bump vscode_extension to 0.4.7

## Test plan
- [ ] `pnpm test` in `node/agent_sdk` passes
- [ ] Subagent events still resolve to the correct parent tool-use item in the webview
- [ ] CLI install/verify failure paths surface useful error logs