### PR TITLE
feat(vscode): support Agent tool and passthrough SubagentEvent fields

### DIFF
--- a/node/agent_sdk/schema.ts
+++ b/node/agent_sdk/schema.ts
@@ -616,7 +616,7 @@ export const SubagentEventSchema = z.lazy(() =>
   z.object({
     parent_tool_call_id: z.string(),
     event: z.object({ type: z.string(), payload: z.unknown() }).transform(parseWireEvent),
-  }),
+  }).passthrough(),
 ) as z.ZodType<SubagentEvent, z.ZodTypeDef, unknown>;
 
 EventSchemas.SubagentEvent = SubagentEventSchema;

--- a/node/vscode_extension/package.json
+++ b/node/vscode_extension/package.json
@@ -3,7 +3,7 @@
   "publisher": "moonshot-ai",
   "displayName": "Kimi Code",
   "description": "Official Kimi Code plugin for VS Code",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/node/vscode_extension/webview-ui/src/components/ToolRenderers.tsx
+++ b/node/vscode_extension/webview-ui/src/components/ToolRenderers.tsx
@@ -324,7 +324,7 @@ function TaskTool({ call, result, subagentSteps }: ToolRendererProps) {
   const [showProcess, setShowProcess] = useState(false);
   const args = parseArgs(call.arguments);
   const description = (args.description as string) || "";
-  const subagentName = (args.subagent_name as string) || "coder";
+  const subagentName = (args.subagent_name as string) || (args.subagent_type as string) || "coder";
   const prompt = (args.prompt as string) || "";
   const hasSubagentSteps = subagentSteps && subagentSteps.length > 0;
 
@@ -422,6 +422,7 @@ export function ToolCallCard({ call, result, subagentSteps }: ToolRendererProps)
       case "Glob":
         return <GlobTool {...props} />;
       case "Task":
+      case "Agent":
         return <TaskTool {...props} />;
       case "SetTodoList":
         return <SetTodoListTool {...props} />;

--- a/node/vscode_extension/webview-ui/src/stores/event-handlers.ts
+++ b/node/vscode_extension/webview-ui/src/stores/event-handlers.ts
@@ -238,7 +238,7 @@ function isTaskToolResult(steps: UIStep[] | undefined, toolCallId: string): bool
     return false;
   }
   const toolItem = findToolUseItem(steps, toolCallId);
-  return toolItem?.call.name === "Task";
+  return toolItem?.call.name === "Task" || toolItem?.call.name === "Agent";
 }
 
 function handlePreflightError(draft: ChatState, code: string, message: string): void {


### PR DESCRIPTION
## Summary
- Render the `Agent` tool using the same UI as `Task` in the webview
- Fall back to `subagent_type` when `subagent_name` is missing on Task/Agent calls
- Treat `Agent` results like `Task` results when resolving subagent steps
- Allow unknown fields on `SubagentEventSchema` via `.passthrough()` for forward compatibility

## Test plan
- [ ] Trigger a tool call named `Agent` and confirm it renders with the Task-style card
- [ ] Confirm subagent steps still attach to their parent tool call
- [ ] Confirm existing `Task` flows are unaffected