### PR TITLE
feat(vscode): hide thinking content details in UI

### DIFF
--- a/node/vscode_extension/package.json
+++ b/node/vscode_extension/package.json
@@ -3,7 +3,7 @@
   "publisher": "moonshot-ai",
   "displayName": "Kimi Code",
   "description": "Official Kimi Code plugin for VS Code",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/node/vscode_extension/webview-ui/src/components/ThinkingBlock.tsx
+++ b/node/vscode_extension/webview-ui/src/components/ThinkingBlock.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { IconChevronDown, IconLoader3, IconBulb } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
-import { Markdown } from "./Markdown";
 import { useSettingsStore } from "@/stores";
 
 interface ThinkingBlockProps {
@@ -34,12 +33,10 @@ export function ThinkingBlock({ content, finished, compact }: ThinkingBlockProps
         <IconChevronDown className={cn("text-zinc-400 ml-auto transition-transform", compact ? "size-3" : "size-3.5", expanded && "rotate-180")} />
       </button>
 
-      {expanded && content && (
-        <Markdown
-          content={content}
-          className={cn("border-t border-zinc-200/50 dark:border-zinc-700/50", compact ? "py-2 px-2 text-[0.75rem]" : "py-3 px-2 pl-3.5 text-xs")}
-          enableEnrichment={finished}
-        />
+      {expanded && (
+        <div className={cn("border-t border-zinc-200/50 dark:border-zinc-700/50 text-zinc-500 dark:text-zinc-400 italic", compact ? "py-2 px-2 text-[0.75rem]" : "py-3 px-2 pl-3.5 text-xs")}>
+          Content hidden
+        </div>
       )}
     </div>
   );

--- a/node/vscode_extension/webview-ui/src/components/ThinkingBlock.tsx
+++ b/node/vscode_extension/webview-ui/src/components/ThinkingBlock.tsx
@@ -1,7 +1,5 @@
-import { useState } from "react";
-import { IconChevronDown, IconLoader3, IconBulb } from "@tabler/icons-react";
+import { IconLoader3, IconBulb } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
-import { useSettingsStore } from "@/stores";
 
 interface ThinkingBlockProps {
   content: string;
@@ -9,35 +7,20 @@ interface ThinkingBlockProps {
   compact?: boolean;
 }
 
-export function ThinkingBlock({ content, finished, compact }: ThinkingBlockProps) {
-  const { extensionConfig } = useSettingsStore();
-
-  const [expanded, setExpanded] = useState(extensionConfig.alwaysExpandThinking);
+export function ThinkingBlock({ finished, compact }: ThinkingBlockProps) {
   const isStreaming = !finished;
-
-  if (!content && !isStreaming) {
-    return null;
-  }
 
   return (
     <div className="rounded-lg border border-zinc-200/50 bg-zinc-50/30 dark:border-zinc-800/50 dark:bg-zinc-900/10 overflow-hidden">
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className={cn("w-full flex items-center gap-2 hover:bg-zinc-100/50 dark:hover:bg-zinc-800/20 transition-colors", compact ? "px-2 py-1.5" : "px-3 py-2")}
+      <div
+        className={cn("w-full flex items-center gap-2", compact ? "px-2 py-1.5" : "px-3 py-2")}
       >
         <div className="inline-flex items-center gap-2">
           <IconBulb className={cn("text-zinc-500", compact ? "size-3" : "size-3.5")} />
           <span className={cn("font-medium text-zinc-700 dark:text-zinc-300", compact ? "text-[0.75rem]" : "text-xs")}>Thinking</span>
           {isStreaming && <IconLoader3 className={cn("text-zinc-400 ml-auto animate-spin", compact ? "size-3" : "size-3.5")} />}
         </div>
-        <IconChevronDown className={cn("text-zinc-400 ml-auto transition-transform", compact ? "size-3" : "size-3.5", expanded && "rotate-180")} />
-      </button>
-
-      {expanded && (
-        <div className={cn("border-t border-zinc-200/50 dark:border-zinc-700/50 text-zinc-500 dark:text-zinc-400 italic", compact ? "py-2 px-2 text-[0.75rem]" : "py-3 px-2 pl-3.5 text-xs")}>
-          Content hidden
-        </div>
-      )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Hide thinking content details in the webview UI

## Test plan
- [ ] Confirm thinking content is no longer rendered in the chat view
- [ ] Confirm non-thinking message content renders as before