### PR TITLE
chore: bump agent_sdk to 0.1.8

### DIFF
--- a/node/agent_sdk/package.json
+++ b/node/agent_sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonshot-ai/kimi-agent-sdk",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "SDK for interacting with Kimi Code CLI",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump `@moonshot-ai/kimi-agent-sdk` to 0.1.8

## Test plan
- [ ] Confirm the published version matches 0.1.8 after release