### PR TITLE
chore: bump vscode_extension to 0.5.0

### DIFF
--- a/node/vscode_extension/package.json
+++ b/node/vscode_extension/package.json
@@ -3,7 +3,7 @@
   "publisher": "moonshot-ai",
   "displayName": "Kimi Code",
   "description": "Official Kimi Code plugin for VS Code",
-  "version": "0.4.9",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump vscode_extension to 0.5.0

## Test plan
- [ ] Confirm the packaged extension reports version 0.5.0