### PR TITLE
feat(vscode): add showThinkingContent option to toggle thinking visibility

### DIFF
--- a/node/vscode_extension/package.json
+++ b/node/vscode_extension/package.json
@@ -3,7 +3,7 @@
   "publisher": "moonshot-ai",
   "displayName": "Kimi Code",
   "description": "Official Kimi Code plugin for VS Code",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/node/vscode_extension/package.json
+++ b/node/vscode_extension/package.json
@@ -82,10 +82,15 @@
             "type": "string"
           }
         },
-        "kimi.alwaysExpandThinking": {
+        "kimi.showThinkingContent": {
           "type": "boolean",
           "default": false,
-          "description": "Auto-expand thinking/reasoning sections so you can see the AI's thought process in real-time"
+          "description": "Show thinking/reasoning content in the chat UI"
+        },
+        "kimi.showThinkingExpanded": {
+          "type": "boolean",
+          "default": false,
+          "description": "Auto-expand thinking/reasoning sections when shown (requires 'Show Thinking Content' to be enabled)"
         },
         "kimi.editorContext": {
           "type": "string",

--- a/node/vscode_extension/shared/types.ts
+++ b/node/vscode_extension/shared/types.ts
@@ -36,7 +36,8 @@ export interface ExtensionConfig {
   useCtrlEnterToSend: boolean;
   enableNewConversationShortcut: boolean;
   environmentVariables: Record<string, string>;
-  alwaysExpandThinking: boolean;
+  showThinkingContent: boolean;
+  showThinkingExpanded: boolean;
   version: string;
 }
 

--- a/node/vscode_extension/src/config/vscode-settings.ts
+++ b/node/vscode_extension/src/config/vscode-settings.ts
@@ -33,8 +33,12 @@ export const VSCodeSettings = {
     return getConfig().get<Record<string, string>>("environmentVariables", {});
   },
 
-  get alwaysExpandThinking(): boolean {
-    return getConfig().get<boolean>("alwaysExpandThinking", false);
+  get showThinkingContent(): boolean {
+    return getConfig().get<boolean>("showThinkingContent", false);
+  },
+
+  get showThinkingExpanded(): boolean {
+    return getConfig().get<boolean>("showThinkingExpanded", false);
   },
 
   get editorContext(): "never" | "onConversationStart" | "onFileChange" {
@@ -49,7 +53,8 @@ export const VSCodeSettings = {
       useCtrlEnterToSend: this.useCtrlEnterToSend,
       enableNewConversationShortcut: this.enableNewConversationShortcut,
       environmentVariables: this.environmentVariables,
-      alwaysExpandThinking: this.alwaysExpandThinking,
+      showThinkingContent: this.showThinkingContent,
+      showThinkingExpanded: this.showThinkingExpanded,
       version: EXTENSION_VERSION,
     };
   },
@@ -60,7 +65,7 @@ export function onSettingsChange(callback: (changedKeys: string[]) => void): vsc
     if (!e.affectsConfiguration("kimi")) {
       return;
     }
-    const keys = ["yoloMode", "autosave", "executablePath", "enableNewConversationShortcut", "useCtrlEnterToSend", "environmentVariables", "alwaysExpandThinking", "editorContext"];
+    const keys = ["yoloMode", "autosave", "executablePath", "enableNewConversationShortcut", "useCtrlEnterToSend", "environmentVariables", "showThinkingContent", "showThinkingExpanded", "editorContext"];
     const changedKeys = keys.filter((key) => e.affectsConfiguration(`kimi.${key}`));
     if (changedKeys.length > 0) {
       callback(changedKeys);

--- a/node/vscode_extension/webview-ui/src/components/ThinkingBlock.tsx
+++ b/node/vscode_extension/webview-ui/src/components/ThinkingBlock.tsx
@@ -1,5 +1,8 @@
-import { IconLoader3, IconBulb } from "@tabler/icons-react";
+import { useState } from "react";
+import { IconChevronDown, IconLoader3, IconBulb } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
+import { Markdown } from "./Markdown";
+import { useSettingsStore } from "@/stores";
 
 interface ThinkingBlockProps {
   content: string;
@@ -7,20 +10,56 @@ interface ThinkingBlockProps {
   compact?: boolean;
 }
 
-export function ThinkingBlock({ finished, compact }: ThinkingBlockProps) {
+export function ThinkingBlock({ content, finished, compact }: ThinkingBlockProps) {
+  const { extensionConfig } = useSettingsStore();
+  const showThinkingContent = extensionConfig.showThinkingContent;
+
+  const [expanded, setExpanded] = useState(extensionConfig.showThinkingExpanded);
   const isStreaming = !finished;
+
+  if (!showThinkingContent) {
+    // Hidden mode: static label, no interaction
+    return (
+      <div className="rounded-lg border border-zinc-200/50 bg-zinc-50/30 dark:border-zinc-800/50 dark:bg-zinc-900/10 overflow-hidden">
+        <div
+          className={cn("w-full flex items-center gap-2", compact ? "px-2 py-1.5" : "px-3 py-2")}
+        >
+          <div className="inline-flex items-center gap-2">
+            <IconBulb className={cn("text-zinc-500", compact ? "size-3" : "size-3.5")} />
+            <span className={cn("font-medium text-zinc-700 dark:text-zinc-300", compact ? "text-[0.75rem]" : "text-xs")}>Thinking</span>
+            {isStreaming && <IconLoader3 className={cn("text-zinc-400 ml-auto animate-spin", compact ? "size-3" : "size-3.5")} />}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Show mode: clickable, expandable/collapsible
+  if (!content && !isStreaming) {
+    return null;
+  }
 
   return (
     <div className="rounded-lg border border-zinc-200/50 bg-zinc-50/30 dark:border-zinc-800/50 dark:bg-zinc-900/10 overflow-hidden">
-      <div
-        className={cn("w-full flex items-center gap-2", compact ? "px-2 py-1.5" : "px-3 py-2")}
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className={cn("w-full flex items-center gap-2 hover:bg-zinc-100/50 dark:hover:bg-zinc-800/20 transition-colors", compact ? "px-2 py-1.5" : "px-3 py-2")}
       >
         <div className="inline-flex items-center gap-2">
           <IconBulb className={cn("text-zinc-500", compact ? "size-3" : "size-3.5")} />
           <span className={cn("font-medium text-zinc-700 dark:text-zinc-300", compact ? "text-[0.75rem]" : "text-xs")}>Thinking</span>
           {isStreaming && <IconLoader3 className={cn("text-zinc-400 ml-auto animate-spin", compact ? "size-3" : "size-3.5")} />}
         </div>
-      </div>
+        <IconChevronDown className={cn("text-zinc-400 ml-auto transition-transform", compact ? "size-3" : "size-3.5", expanded && "rotate-180")} />
+      </button>
+
+      {expanded && content && (
+        <Markdown
+          content={content}
+          className={cn("border-t border-zinc-200/50 dark:border-zinc-700/50", compact ? "py-2 px-2 text-[0.75rem]" : "py-3 px-2 pl-3.5 text-xs")}
+          enableEnrichment={finished}
+        />
+      )}
     </div>
   );
 }

--- a/node/vscode_extension/webview-ui/src/stores/settings.store.ts
+++ b/node/vscode_extension/webview-ui/src/stores/settings.store.ts
@@ -10,7 +10,8 @@ export const DEFAULT_EXTENSION_CONFIG: ExtensionConfig = {
   useCtrlEnterToSend: false,
   enableNewConversationShortcut: false,
   environmentVariables: {},
-  alwaysExpandThinking: false,
+  showThinkingContent: false,
+  showThinkingExpanded: false,
   version: "",
 };
 


### PR DESCRIPTION
## What

Add a VS Code setting `kimi.showThinkingContent` (default: `false`) that lets users toggle whether thinking/reasoning content is visible and expandable in the chat UI.

## Changes

- **`kimi.showThinkingContent`** (new, default `false`): controls whether thinking content is shown
- **`kimi.showThinkingExpanded`** (renamed from `alwaysExpandThinking`): auto-expand thinking sections when shown. Renamed so both thinking settings sort together alphabetically in VS Code Settings UI.

### Behavior

| showThinkingContent | UI |
|---|---|
| `false` (default) | Static "Thinking" label, no interaction |
| `true` | Clickable expand/collapse button with thinking content |

## Files changed

- `package.json` — new setting + rename
- `shared/types.ts` — ExtensionConfig type
- `src/config/vscode-settings.ts` — getter, sync, change listener
- `webview-ui/src/stores/settings.store.ts` — default values
- `webview-ui/src/components/ThinkingBlock.tsx` — conditional rendering logic