### PR TITLE
chore(vscode): default showThinkingExpanded to true

### DIFF
--- a/node/vscode_extension/package.json
+++ b/node/vscode_extension/package.json
@@ -3,7 +3,7 @@
   "publisher": "moonshot-ai",
   "displayName": "Kimi Code",
   "description": "Official Kimi Code plugin for VS Code",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -84,7 +84,7 @@
         },
         "kimi.showThinkingContent": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Show thinking/reasoning content in the chat UI"
         },
         "kimi.showThinkingExpanded": {

--- a/node/vscode_extension/package.json
+++ b/node/vscode_extension/package.json
@@ -3,7 +3,7 @@
   "publisher": "moonshot-ai",
   "displayName": "Kimi Code",
   "description": "Official Kimi Code plugin for VS Code",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/node/vscode_extension/package.json
+++ b/node/vscode_extension/package.json
@@ -89,7 +89,7 @@
         },
         "kimi.showThinkingExpanded": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Auto-expand thinking/reasoning sections when shown (requires 'Show Thinking Content' to be enabled)"
         },
         "kimi.editorContext": {

--- a/node/vscode_extension/webview-ui/src/stores/settings.store.ts
+++ b/node/vscode_extension/webview-ui/src/stores/settings.store.ts
@@ -10,7 +10,7 @@ export const DEFAULT_EXTENSION_CONFIG: ExtensionConfig = {
   useCtrlEnterToSend: false,
   enableNewConversationShortcut: false,
   environmentVariables: {},
-  showThinkingContent: false,
+  showThinkingContent: true,
   showThinkingExpanded: true,
   version: "",
 };

--- a/node/vscode_extension/webview-ui/src/stores/settings.store.ts
+++ b/node/vscode_extension/webview-ui/src/stores/settings.store.ts
@@ -11,7 +11,7 @@ export const DEFAULT_EXTENSION_CONFIG: ExtensionConfig = {
   enableNewConversationShortcut: false,
   environmentVariables: {},
   showThinkingContent: false,
-  showThinkingExpanded: false,
+  showThinkingExpanded: true,
   version: "",
 };
 


### PR DESCRIPTION
Set `kimi.showThinkingExpanded` default to `true`, so when users enable Show Thinking Content, thinking sections are expanded by default.