### PR TITLE
chore: bump vscode extension version to 0.5.5

### DIFF
--- a/node/vscode_extension/package.json
+++ b/node/vscode_extension/package.json
@@ -3,7 +3,7 @@
   "publisher": "moonshot-ai",
   "displayName": "Kimi Code",
   "description": "Official Kimi Code plugin for VS Code",
-  "version": "0.5.3",
+  "version": "0.5.5",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Changes

- Bump VSCode extension version from `0.5.3` to `0.5.5` (CLI updated)