### PR TITLE
feat(vscode-extension): improve slash command selection and sort order

### DIFF
--- a/node/vscode_extension/webview-ui/src/components/inputarea/InputArea.tsx
+++ b/node/vscode_extension/webview-ui/src/components/inputarea/InputArea.tsx
@@ -154,8 +154,19 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
   });
 
   const handleSlashCommand = useMemoizedFn((name: string) => {
-    sendMessage(`/${name}`);
-    clearInput();
+    if (!activeToken) return;
+    const before = text.slice(0, activeToken.start);
+    const after = text.slice(cursorPos);
+    const newText = `${before}/${name} ${after}`;
+    const newCursorPos = activeToken.start + 1 + name.length + 1;
+
+    setText(newText);
+    setCursorPos(newCursorPos);
+    setTimeout(() => {
+      textareaRef.current?.setSelectionRange(newCursorPos, newCursorPos);
+      textareaRef.current?.focus();
+      adjustHeight();
+    }, 0);
   });
 
   const applyMention = useMemoizedFn((filePath: string) => {

--- a/node/vscode_extension/webview-ui/src/components/inputarea/hooks/useSlashMenu.ts
+++ b/node/vscode_extension/webview-ui/src/components/inputarea/hooks/useSlashMenu.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState, useCallback } from "react";
+import { useMemo, useState, useCallback, useEffect } from "react";
 import { useSettingsStore } from "@/stores";
 import type { SlashCommandInfo } from "@moonshot-ai/kimi-agent-sdk";
 
@@ -21,6 +21,21 @@ function fuzzyMatch(text: string, query: string): boolean {
     }
   }
   return qi === lowerQuery.length;
+}
+
+function scoreMatch(cmd: SlashCommandInfo, query: string): number {
+  if (!query) return 0;
+  const lowerName = cmd.name.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+
+  if (lowerName === lowerQuery) return 1000;
+  if (lowerName.startsWith(lowerQuery)) return 100;
+
+  const desc = (cmd.description || "").toLowerCase();
+  if (desc.startsWith(lowerQuery)) return 10;
+  if (desc.includes(lowerQuery)) return 1;
+
+  return 0;
 }
 
 export function findActiveToken(text: string, cursorPos: number): ActiveToken | null {
@@ -60,8 +75,14 @@ export function useSlashMenu(activeToken: ActiveToken | null, onSelectCommand: (
     if (!q) {
       return slashCommands;
     }
-    return slashCommands.filter((cmd) => fuzzyMatch(cmd.name, q) || fuzzyMatch(cmd.description, q));
+    return slashCommands
+      .filter((cmd) => fuzzyMatch(cmd.name, q) || fuzzyMatch(cmd.description, q))
+      .sort((a, b) => scoreMatch(b, q) - scoreMatch(a, q));
   }, [showSlashMenu, activeToken?.query, slashCommands]);
+
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [filteredCommands]);
 
   const resetSlashMenu = useCallback(() => {
     setSelectedIndex(0);


### PR DESCRIPTION
- Insert slash command at cursor position with proper focus handling instead of sending message immediately and clearing input
- Add scoreMatch() to rank slash command matches by relevance (exact match > prefix match > description prefix > description contains)
- Reset selected index when filtered command list changes