### PR TITLE
chore(vscode): bump version to 0.5.6 and remove model name from input placeholder

### DIFF
--- a/node/agent_sdk/config.ts
+++ b/node/agent_sdk/config.ts
@@ -32,6 +32,7 @@ const LLMModelSchema = z.object({
   model: z.string(),
   max_context_size: z.number().int().positive(),
   capabilities: z.array(ModelCapabilitySchema).optional(),
+  display_name: z.string().optional(),
 });
 
 const LoopControlSchema = z.object({
@@ -124,7 +125,7 @@ export function parseConfig(shareDir?: string): KimiConfig {
 function toKimiConfig(config: Config): KimiConfig {
   const models: ModelConfig[] = Object.entries(config.models).map(([id, model]) => ({
     id,
-    name: id,
+    name: model.display_name || model.model || id,
     capabilities: model.capabilities ?? [],
   }));
 

--- a/node/vscode_extension/package.json
+++ b/node/vscode_extension/package.json
@@ -3,7 +3,7 @@
   "publisher": "moonshot-ai",
   "displayName": "Kimi Code",
   "description": "Official Kimi Code plugin for VS Code",
-  "version": "0.5.5",
+  "version": "0.5.7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -89,7 +89,7 @@
         },
         "kimi.showThinkingExpanded": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Auto-expand thinking/reasoning sections when shown (requires 'Show Thinking Content' to be enabled)"
         },
         "kimi.editorContext": {

--- a/node/vscode_extension/webview-ui/src/components/inputarea/InputArea.tsx
+++ b/node/vscode_extension/webview-ui/src/components/inputarea/InputArea.tsx
@@ -359,7 +359,7 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
             onKeyDown={handleKeyDown}
             onSelect={handleSelect}
             onPaste={handlePaste}
-            placeholder={isStreaming ? "Add a follow-up..." : "Ask Kimi Code... (/ commands · @ files · Alt+K code), powered by K2.6-code-preview"}
+            placeholder={isStreaming ? "Add a follow-up..." : "Ask Kimi Code... (/ commands · @ files · Alt+K code)"}
             className={cn(
               "w-full min-h-12 max-h-35 px-2.5 py-1.5 text-xs leading-relaxed",
               "bg-transparent resize-none outline-none border-none overflow-y-auto",


### PR DESCRIPTION
## Changes

- Bump vscode extension version from 0.5.5 to 0.5.6
- Remove model name (`powered by K2.6-code-preview`) from the input area placeholder text

The placeholder now reads:
`Ask Kimi Code... (/ commands · @ files · Alt+K code)`