### PR TITLE
python: bump kimi-cli to 1.37 and keep skills_dir compatibility

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Unreleased
 
+- Dependencies: Update kimi-cli to version 1.37, kosong to version 0.50
+
 ## 0.0.5 (2026-02-11)
 - Dependencies: Update kimi-cli to version 1.12
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,8 +19,8 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
 ]
 dependencies = [
-    "kimi-cli>=1.12.0,<1.13.0",
-    "kosong>=0.42.0,<0.43.0",
+    "kimi-cli>=1.37.0,<1.38.0",
+    "kosong>=0.50.0,<0.51.0",
 ]
 
 [project.urls]

--- a/python/src/kimi_agent_sdk/_prompt.py
+++ b/python/src/kimi_agent_sdk/_prompt.py
@@ -34,6 +34,7 @@ async def prompt(
     agent_file: Path | None = None,
     mcp_configs: list[MCPConfig] | list[dict[str, Any]] | None = None,
     skills_dir: KaosPath | None = None,
+    skills_dirs: list[KaosPath] | None = None,
     # Loop control
     max_steps_per_turn: int | None = None,
     max_retries_per_step: int | None = None,
@@ -57,7 +58,8 @@ async def prompt(
         approval_handler_fn: Custom approval handler callback (sync or async).
         agent_file: Agent specification file path.
         mcp_configs: MCP server configurations.
-        skills_dir: Skills directory (KaosPath).
+        skills_dir: Single skills directory (KaosPath). Preserved for SDK compatibility.
+        skills_dirs: Multiple skills directories (KaosPath list) for newer kimi-cli.
         max_steps_per_turn: Maximum number of steps in one turn.
         max_retries_per_step: Maximum number of retries per step.
         max_ralph_iterations: Extra iterations in Ralph mode (-1 for unlimited).
@@ -99,6 +101,7 @@ async def prompt(
         agent_file=agent_file,
         mcp_configs=mcp_configs,
         skills_dir=skills_dir,
+        skills_dirs=skills_dirs,
         max_steps_per_turn=max_steps_per_turn,
         max_retries_per_step=max_retries_per_step,
         max_ralph_iterations=max_ralph_iterations,

--- a/python/src/kimi_agent_sdk/_session.py
+++ b/python/src/kimi_agent_sdk/_session.py
@@ -24,6 +24,25 @@ def _ensure_type(name: str, value: object, expected: type) -> None:
         raise TypeError(f"{name} must be {expected.__name__}, got {type(value).__name__}")
 
 
+def _resolve_skills_dirs(
+    skills_dir: KaosPath | None,
+    skills_dirs: list[KaosPath] | None,
+) -> list[KaosPath] | None:
+    resolved: list[KaosPath] = []
+
+    if skills_dir is not None:
+        _ensure_type("skills_dir", skills_dir, KaosPath)
+        resolved.append(skills_dir)
+
+    if skills_dirs is not None:
+        _ensure_type("skills_dirs", skills_dirs, list)
+        for idx, item in enumerate(skills_dirs):
+            _ensure_type(f"skills_dirs[{idx}]", item, KaosPath)
+        resolved.extend(skills_dirs)
+
+    return resolved or None
+
+
 class Session:
     """
     Kimi Agent session with low-level control.
@@ -52,6 +71,7 @@ class Session:
         agent_file: Path | None = None,
         mcp_configs: list[MCPConfig] | list[dict[str, Any]] | None = None,
         skills_dir: KaosPath | None = None,
+        skills_dirs: list[KaosPath] | None = None,
         # Loop control
         max_steps_per_turn: int | None = None,
         max_retries_per_step: int | None = None,
@@ -69,7 +89,8 @@ class Session:
             yolo: Automatically approve all approval requests.
             agent_file: Agent specification file path.
             mcp_configs: MCP server configurations.
-            skills_dir: Skills directory (KaosPath).
+            skills_dir: Single skills directory (KaosPath). Preserved for SDK compatibility.
+            skills_dirs: Multiple skills directories (KaosPath list) for newer kimi-cli.
             max_steps_per_turn: Maximum number of steps in one turn.
             max_retries_per_step: Maximum number of retries per step.
             max_ralph_iterations: Extra iterations in Ralph mode (-1 for unlimited).
@@ -92,8 +113,7 @@ class Session:
             _ensure_type("work_dir", work_dir, KaosPath)
             work_dir_path = work_dir
 
-        if skills_dir is not None:
-            _ensure_type("skills_dir", skills_dir, KaosPath)
+        resolved_skills_dirs = _resolve_skills_dirs(skills_dir, skills_dirs)
         cli_session = await CliSession.create(work_dir_path, session_id)
         cli = await KimiCLI.create(
             cli_session,
@@ -103,7 +123,7 @@ class Session:
             yolo=yolo,
             agent_file=agent_file,
             mcp_configs=mcp_configs,
-            skills_dir=skills_dir,
+            skills_dirs=resolved_skills_dirs,
             max_steps_per_turn=max_steps_per_turn,
             max_retries_per_step=max_retries_per_step,
             max_ralph_iterations=max_ralph_iterations,
@@ -125,6 +145,7 @@ class Session:
         agent_file: Path | None = None,
         mcp_configs: list[MCPConfig] | list[dict[str, Any]] | None = None,
         skills_dir: KaosPath | None = None,
+        skills_dirs: list[KaosPath] | None = None,
         # Loop control
         max_steps_per_turn: int | None = None,
         max_retries_per_step: int | None = None,
@@ -142,7 +163,8 @@ class Session:
             yolo: Automatically approve all approval requests.
             agent_file: Agent specification file path.
             mcp_configs: MCP server configurations.
-            skills_dir: Skills directory (KaosPath).
+            skills_dir: Single skills directory (KaosPath). Preserved for SDK compatibility.
+            skills_dirs: Multiple skills directories (KaosPath list) for newer kimi-cli.
             max_steps_per_turn: Maximum number of steps in one turn.
             max_retries_per_step: Maximum number of retries per step.
             max_ralph_iterations: Extra iterations in Ralph mode (-1 for unlimited).
@@ -160,8 +182,7 @@ class Session:
                 connected.
         """
         _ensure_type("work_dir", work_dir, KaosPath)
-        if skills_dir is not None:
-            _ensure_type("skills_dir", skills_dir, KaosPath)
+        resolved_skills_dirs = _resolve_skills_dirs(skills_dir, skills_dirs)
         if session_id is None:
             cli_session = await CliSession.continue_(work_dir)
         else:
@@ -176,7 +197,7 @@ class Session:
             yolo=yolo,
             agent_file=agent_file,
             mcp_configs=mcp_configs,
-            skills_dir=skills_dir,
+            skills_dirs=resolved_skills_dirs,
             max_steps_per_turn=max_steps_per_turn,
             max_retries_per_step=max_retries_per_step,
             max_ralph_iterations=max_ralph_iterations,

--- a/python/tests/test_paths.py
+++ b/python/tests/test_paths.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 
 import pytest
 from kaos.path import KaosPath
+from kosong.message import Message
 
 from kimi_agent_sdk import Session, prompt
 from kimi_agent_sdk import _prompt as prompt_module
@@ -113,7 +114,7 @@ async def test_prompt_forwards_skills_dirs(monkeypatch: pytest.MonkeyPatch) -> N
 
     monkeypatch.setattr(prompt_module.Session, "create", _dummy_session_create)
 
-    results = []
+    results: list[Message] = []
     async for message in prompt(
         "hi",
         yolo=True,

--- a/python/tests/test_paths.py
+++ b/python/tests/test_paths.py
@@ -96,7 +96,7 @@ async def test_prompt_forwards_skills_dirs(monkeypatch: pytest.MonkeyPatch) -> N
     captured_kwargs: dict[str, Any] = {}
 
     class _DummySessionContext:
-        async def __aenter__(self) -> "_DummySessionContext":
+        async def __aenter__(self) -> _DummySessionContext:
             return self
 
         async def __aexit__(self, *_args: Any) -> None:

--- a/python/tests/test_paths.py
+++ b/python/tests/test_paths.py
@@ -41,11 +41,20 @@ async def test_prompt_requires_kaos_skills_dir() -> None:
 
 
 @pytest.mark.asyncio
+async def test_session_create_requires_kaos_skills_dirs() -> None:
+    with pytest.raises(TypeError, match=r"skills_dirs\[0\] must be KaosPath"):
+        await Session.create(work_dir=KaosPath.cwd(), skills_dirs=[cast(Any, Path("."))])
+
+
+@pytest.mark.asyncio
 async def test_session_create_accepts_kaos_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_kwargs: dict[str, Any] = {}
+
     async def _dummy_session_create(*_args: Any, **_kwargs: Any) -> Any:
         return object()
 
     async def _dummy_cli_create(*_args: Any, **_kwargs: Any) -> Any:
+        captured_kwargs.update(_kwargs)
         return cast(Any, object())
 
     monkeypatch.setattr(session_module.CliSession, "create", _dummy_session_create)
@@ -53,3 +62,4 @@ async def test_session_create_accepts_kaos_paths(monkeypatch: pytest.MonkeyPatch
 
     session = await Session.create(work_dir=KaosPath.cwd(), skills_dir=KaosPath.cwd())
     assert isinstance(session, Session)
+    assert captured_kwargs["skills_dirs"] == [KaosPath.cwd()]

--- a/python/tests/test_paths.py
+++ b/python/tests/test_paths.py
@@ -7,6 +7,7 @@ import pytest
 from kaos.path import KaosPath
 
 from kimi_agent_sdk import Session, prompt
+from kimi_agent_sdk import _prompt as prompt_module
 from kimi_agent_sdk import _session as session_module
 
 
@@ -62,4 +63,63 @@ async def test_session_create_accepts_kaos_paths(monkeypatch: pytest.MonkeyPatch
 
     session = await Session.create(work_dir=KaosPath.cwd(), skills_dir=KaosPath.cwd())
     assert isinstance(session, Session)
+    assert captured_kwargs["skills_dirs"] == [KaosPath.cwd()]
+
+
+@pytest.mark.asyncio
+async def test_session_resume_accepts_kaos_skills_dirs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_kwargs: dict[str, Any] = {}
+
+    async def _dummy_find(*_args: Any, **_kwargs: Any) -> Any:
+        return object()
+
+    async def _dummy_cli_create(*_args: Any, **_kwargs: Any) -> Any:
+        captured_kwargs.update(_kwargs)
+        return cast(Any, object())
+
+    monkeypatch.setattr(session_module.CliSession, "find", _dummy_find)
+    monkeypatch.setattr(session_module.KimiCLI, "create", _dummy_cli_create)
+
+    session = await Session.resume(
+        KaosPath.cwd(),
+        session_id="test-session",
+        skills_dirs=[KaosPath.cwd()],
+    )
+    assert isinstance(session, Session)
+    assert captured_kwargs["skills_dirs"] == [KaosPath.cwd()]
+
+
+@pytest.mark.asyncio
+async def test_prompt_forwards_skills_dirs(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_kwargs: dict[str, Any] = {}
+
+    class _DummySessionContext:
+        async def __aenter__(self) -> "_DummySessionContext":
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            return None
+
+        async def prompt(self, *_args: Any, **_kwargs: Any):  # type: ignore[no-untyped-def]
+            if False:
+                yield None
+            return
+
+    async def _dummy_session_create(*_args: Any, **kwargs: Any) -> Any:
+        captured_kwargs.update(kwargs)
+        return _DummySessionContext()
+
+    monkeypatch.setattr(prompt_module.Session, "create", _dummy_session_create)
+
+    results = []
+    async for message in prompt(
+        "hi",
+        yolo=True,
+        skills_dirs=[KaosPath.cwd()],
+    ):
+        results.append(message)
+
+    assert results == []
     assert captured_kwargs["skills_dirs"] == [KaosPath.cwd()]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -8,14 +8,14 @@ resolution-markers = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/4d/e33e4e997de8fdc6c7154e59490a20c455cd46543b62dab768ae99317046/agent_client_protocol-0.7.0.tar.gz", hash = "sha256:c66811bb804868c4e7728b18b67379bcb0335afba3b1c2ff0fcdfd0c48d93029", size = 64809, upload-time = "2025-12-04T16:17:34.568Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/a4/26698e0186933b4ab6e814626c99ee52b5522d039b5c94c983ecb3a66eed/agent_client_protocol-0.8.0.tar.gz", hash = "sha256:f9eade29167ff72a10fae7a0a0c1f27436909a790e159fb10265c2874e58d922", size = 68577, upload-time = "2026-02-07T17:08:46.513Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/02/257ea400cfee72a48dabe04ef0a984c496c9687830cf7977b327979e8cd7/agent_client_protocol-0.7.0-py3-none-any.whl", hash = "sha256:71fce4088fe7faa85b30278aecd1d8d6012f03505ae2ee6e312f9e2ba4ea1f4e", size = 52922, upload-time = "2025-12-04T16:17:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/04/e55a3c549c09c0023cb92c696c7b98d97bb657088f940e34f4bc47d1a49a/agent_client_protocol-0.8.0-py3-none-any.whl", hash = "sha256:2d5712b88b3249dbd6148b24d32c6eb8992e5663f224db6291524ac80cca8037", size = 54362, upload-time = "2026-02-07T17:08:45.575Z" },
 ]
 
 [[package]]
@@ -1222,8 +1222,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "kimi-cli", specifier = ">=1.12.0,<1.13.0" },
-    { name = "kosong", specifier = ">=0.42.0,<0.43.0" },
+    { name = "kimi-cli", specifier = ">=1.37.0,<1.38.0" },
+    { name = "kosong", specifier = ">=0.50.0,<0.51.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1239,7 +1239,7 @@ dev = [
 
 [[package]]
 name = "kimi-cli"
-version = "1.12.0"
+version = "1.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1263,6 +1263,7 @@ dependencies = [
     { name = "rich" },
     { name = "ripgrepy" },
     { name = "scalar-fastapi" },
+    { name = "setproctitle" },
     { name = "streamingjson" },
     { name = "tenacity" },
     { name = "tomlkit" },
@@ -1271,14 +1272,14 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/40/fc1414b7b97f08213afcaf1365a45a446ce947df6669994a2c0240e5a1fa/kimi_cli-1.12.0.tar.gz", hash = "sha256:53f4b5809ffedb688692abf68d8fe8d965a9d5d9007ef47c7de3a05e08319ec7", size = 4460337, upload-time = "2026-02-11T14:43:52.578Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/72/2c0097cdaa809b08193bebb81a06ae578a7d21d8e64938755a5d08e68961/kimi_cli-1.37.0.tar.gz", hash = "sha256:ce3258cbb6086f5759b71b24ce035013644bdf4f68a3b7e0d83e6074718211fb", size = 5241322, upload-time = "2026-04-20T15:47:57.53Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/94/cbe9a985494c0e07a9530291c312e79b2f0aa6160786823fb79eaa937dcd/kimi_cli-1.12.0-py3-none-any.whl", hash = "sha256:5efc404c3cc4e038f2657866666ce9199d48ae7d3f3055dbb31d76c048f926fc", size = 4728694, upload-time = "2026-02-11T14:43:49.211Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c3/df9055f74e8c124683f667c8627b98c6a957fd120841bfbdbefb7dafe130/kimi_cli-1.37.0-py3-none-any.whl", hash = "sha256:dcae0d9aef5b2afc25ad8057ff06ea2445e56721534bf5e0b31f7b7e267db9a2", size = 5548753, upload-time = "2026-04-20T15:47:54.951Z" },
 ]
 
 [[package]]
 name = "kosong"
-version = "0.42.0"
+version = "0.50.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
@@ -1291,9 +1292,9 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/fd/548285e161e61ff5a88aa32a6feb48424a237f677e6c0be72122852a8554/kosong-0.42.0.tar.gz", hash = "sha256:b6d2427250673b614783a032f42f71e29e4a359f717103ba9103172cfef28ef7", size = 39657, upload-time = "2026-02-06T18:26:25.645Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/95/7629f882b6ebb276531fc5c45a9f3a39d585b90818c33ebce9a5aee6132c/kosong-0.50.0.tar.gz", hash = "sha256:bf111ad817d93e55d57f42c89d63f6954516ce02190cf308a1a54c41ffef5618", size = 45531, upload-time = "2026-04-17T13:57:15.404Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/46/982b18061b90c02968d2cea0119302798a028103f6b351bfcdb464afb03c/kosong-0.42.0-py3-none-any.whl", hash = "sha256:022cb73ecac0bc88898f251b394fcb4209eeedf53cf455742655b877a27b23a9", size = 59043, upload-time = "2026-02-06T18:26:24.697Z" },
+    { url = "https://files.pythonhosted.org/packages/70/60/1a76a252578bc7954a86588dd5776ed73061cd62f45378930773b3f1073f/kosong-0.50.0-py3-none-any.whl", hash = "sha256:ec6130600f13f194e934d98aa10ca7267116a405134c2905a356359ff5807d29", size = 65060, upload-time = "2026-04-17T13:57:14.111Z" },
 ]
 
 [package.optional-dependencies]
@@ -2177,15 +2178,15 @@ wheels = [
 
 [[package]]
 name = "pykaos"
-version = "0.7.0"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
     { name = "asyncssh" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/a3/6579427249f03ad3c9781c53d0de57348c031eae99a34c2607c06cb20a08/pykaos-0.7.0.tar.gz", hash = "sha256:e8623749abb1f7f88681237f2799af50113e365288969afe091fadb19562c41c", size = 7785, upload-time = "2026-02-06T18:26:28.771Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/53/5fac4795ceaf01027726bcfc25308e67cefc994638236683e0c1327107c9/pykaos-0.9.0.tar.gz", hash = "sha256:9a81a2e0548ec6f8051fe3d1021fdb70360c606dc08dfacf4fee65e8ae39d035", size = 7798, upload-time = "2026-04-02T14:25:57.805Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/64/3bd78c6b6ebd373378e6e9c61b14ecb6b651e97aac134dc99245b303c8ca/pykaos-0.7.0-py3-none-any.whl", hash = "sha256:64d873f96d479efa82f4644f994e9b9ceb8e5974ce128605521ea96967c04f79", size = 10758, upload-time = "2026-02-06T18:26:27.578Z" },
+    { url = "https://files.pythonhosted.org/packages/80/26/e3b800793ced194a8e1a1a3f6dbfbb2b48231cdfcb0aecc8f52ec890a09a/pykaos-0.9.0-py3-none-any.whl", hash = "sha256:a725910ff167131dbda91e502f40c3b5ff8b67652358ecdd810a0e0339775e10", size = 10774, upload-time = "2026-04-02T14:25:56.893Z" },
 ]
 
 [[package]]
@@ -2687,6 +2688,64 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
+name = "setproctitle"
+version = "1.3.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/48/49393a96a2eef1ab418b17475fb92b8fcfad83d099e678751b05472e69de/setproctitle-1.3.7.tar.gz", hash = "sha256:bc2bc917691c1537d5b9bca1468437176809c7e11e5694ca79a9ca12345dcb9e", size = 27002, upload-time = "2025-09-05T12:51:25.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/f0/2dc88e842077719d7384d86cc47403e5102810492b33680e7dadcee64cd8/setproctitle-1.3.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2dc99aec591ab6126e636b11035a70991bc1ab7a261da428491a40b84376654e", size = 18049, upload-time = "2025-09-05T12:49:36.241Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b4/50940504466689cda65680c9e9a1e518e5750c10490639fa687489ac7013/setproctitle-1.3.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cdd8aa571b7aa39840fdbea620e308a19691ff595c3a10231e9ee830339dd798", size = 13079, upload-time = "2025-09-05T12:49:38.088Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/99/71630546b9395b095f4082be41165d1078204d1696c2d9baade3de3202d0/setproctitle-1.3.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2906b6c7959cdb75f46159bf0acd8cc9906cf1361c9e1ded0d065fe8f9039629", size = 32932, upload-time = "2025-09-05T12:49:39.271Z" },
+    { url = "https://files.pythonhosted.org/packages/50/22/cee06af4ffcfb0e8aba047bd44f5262e644199ae7527ae2c1f672b86495c/setproctitle-1.3.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6915964a6dda07920a1159321dcd6d94fc7fc526f815ca08a8063aeca3c204f1", size = 33736, upload-time = "2025-09-05T12:49:40.565Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/00/a5949a8bb06ef5e7df214fc393bb2fb6aedf0479b17214e57750dfdd0f24/setproctitle-1.3.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cff72899861c765bd4021d1ff1c68d60edc129711a2fdba77f9cb69ef726a8b6", size = 35605, upload-time = "2025-09-05T12:49:42.362Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3a/50caca532a9343828e3bf5778c7a84d6c737a249b1796d50dd680290594d/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b7cb05bd446687ff816a3aaaf831047fc4c364feff7ada94a66024f1367b448c", size = 33143, upload-time = "2025-09-05T12:49:43.515Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/14/b843a251296ce55e2e17c017d6b9f11ce0d3d070e9265de4ecad948b913d/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:3a57b9a00de8cae7e2a1f7b9f0c2ac7b69372159e16a7708aa2f38f9e5cc987a", size = 34434, upload-time = "2025-09-05T12:49:45.31Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b7/06145c238c0a6d2c4bc881f8be230bb9f36d2bf51aff7bddcb796d5eed67/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d8828b356114f6b308b04afe398ed93803d7fca4a955dd3abe84430e28d33739", size = 32795, upload-time = "2025-09-05T12:49:46.419Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/dc/ef76a81fac9bf27b84ed23df19c1f67391a753eed6e3c2254ebcb5133f56/setproctitle-1.3.7-cp312-cp312-win32.whl", hash = "sha256:b0304f905efc845829ac2bc791ddebb976db2885f6171f4a3de678d7ee3f7c9f", size = 12552, upload-time = "2025-09-05T12:49:47.635Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5b/a9fe517912cd6e28cf43a212b80cb679ff179a91b623138a99796d7d18a0/setproctitle-1.3.7-cp312-cp312-win_amd64.whl", hash = "sha256:9888ceb4faea3116cf02a920ff00bfbc8cc899743e4b4ac914b03625bdc3c300", size = 13247, upload-time = "2025-09-05T12:49:49.16Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/2f/fcedcade3b307a391b6e17c774c6261a7166aed641aee00ed2aad96c63ce/setproctitle-1.3.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c3736b2a423146b5e62230502e47e08e68282ff3b69bcfe08a322bee73407922", size = 18047, upload-time = "2025-09-05T12:49:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ae/afc141ca9631350d0a80b8f287aac79a76f26b6af28fd8bf92dae70dc2c5/setproctitle-1.3.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3384e682b158d569e85a51cfbde2afd1ab57ecf93ea6651fe198d0ba451196ee", size = 13073, upload-time = "2025-09-05T12:49:51.46Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ed/0a4f00315bc02510395b95eec3d4aa77c07192ee79f0baae77ea7b9603d8/setproctitle-1.3.7-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0564a936ea687cd24dffcea35903e2a20962aa6ac20e61dd3a207652401492dd", size = 33284, upload-time = "2025-09-05T12:49:52.741Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/e4/adf3c4c0a2173cb7920dc9df710bcc67e9bcdbf377e243b7a962dc31a51a/setproctitle-1.3.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5d1cb3f81531f0eb40e13246b679a1bdb58762b170303463cb06ecc296f26d0", size = 34104, upload-time = "2025-09-05T12:49:54.416Z" },
+    { url = "https://files.pythonhosted.org/packages/52/4f/6daf66394152756664257180439d37047aa9a1cfaa5e4f5ed35e93d1dc06/setproctitle-1.3.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a7d159e7345f343b44330cbba9194169b8590cb13dae940da47aa36a72aa9929", size = 35982, upload-time = "2025-09-05T12:49:56.295Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/62/f2c0595403cf915db031f346b0e3b2c0096050e90e0be658a64f44f4278a/setproctitle-1.3.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0b5074649797fd07c72ca1f6bff0406f4a42e1194faac03ecaab765ce605866f", size = 33150, upload-time = "2025-09-05T12:49:58.025Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/29/10dd41cde849fb2f9b626c846b7ea30c99c81a18a5037a45cc4ba33c19a7/setproctitle-1.3.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:61e96febced3f61b766115381d97a21a6265a0f29188a791f6df7ed777aef698", size = 34463, upload-time = "2025-09-05T12:49:59.424Z" },
+    { url = "https://files.pythonhosted.org/packages/71/3c/cedd8eccfaf15fb73a2c20525b68c9477518917c9437737fa0fda91e378f/setproctitle-1.3.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:047138279f9463f06b858e579cc79580fbf7a04554d24e6bddf8fe5dddbe3d4c", size = 32848, upload-time = "2025-09-05T12:50:01.107Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3e/0a0e27d1c9926fecccfd1f91796c244416c70bf6bca448d988638faea81d/setproctitle-1.3.7-cp313-cp313-win32.whl", hash = "sha256:7f47accafac7fe6535ba8ba9efd59df9d84a6214565108d0ebb1199119c9cbbd", size = 12544, upload-time = "2025-09-05T12:50:15.81Z" },
+    { url = "https://files.pythonhosted.org/packages/36/1b/6bf4cb7acbbd5c846ede1c3f4d6b4ee52744d402e43546826da065ff2ab7/setproctitle-1.3.7-cp313-cp313-win_amd64.whl", hash = "sha256:fe5ca35aeec6dc50cabab9bf2d12fbc9067eede7ff4fe92b8f5b99d92e21263f", size = 13235, upload-time = "2025-09-05T12:50:16.89Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/a4/d588d3497d4714750e3eaf269e9e8985449203d82b16b933c39bd3fc52a1/setproctitle-1.3.7-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:10e92915c4b3086b1586933a36faf4f92f903c5554f3c34102d18c7d3f5378e9", size = 18058, upload-time = "2025-09-05T12:50:02.501Z" },
+    { url = "https://files.pythonhosted.org/packages/05/77/7637f7682322a7244e07c373881c7e982567e2cb1dd2f31bd31481e45500/setproctitle-1.3.7-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:de879e9c2eab637f34b1a14c4da1e030c12658cdc69ee1b3e5be81b380163ce5", size = 13072, upload-time = "2025-09-05T12:50:03.601Z" },
+    { url = "https://files.pythonhosted.org/packages/52/09/f366eca0973cfbac1470068d1313fa3fe3de4a594683385204ec7f1c4101/setproctitle-1.3.7-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c18246d88e227a5b16248687514f95642505000442165f4b7db354d39d0e4c29", size = 34490, upload-time = "2025-09-05T12:50:04.948Z" },
+    { url = "https://files.pythonhosted.org/packages/71/36/611fc2ed149fdea17c3677e1d0df30d8186eef9562acc248682b91312706/setproctitle-1.3.7-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7081f193dab22df2c36f9fc6d113f3793f83c27891af8fe30c64d89d9a37e152", size = 35267, upload-time = "2025-09-05T12:50:06.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a4/64e77d0671446bd5a5554387b69e1efd915274686844bea733714c828813/setproctitle-1.3.7-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9cc9b901ce129350637426a89cfd650066a4adc6899e47822e2478a74023ff7c", size = 37376, upload-time = "2025-09-05T12:50:07.484Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/ad9c664fe524fb4a4b2d3663661a5c63453ce851736171e454fa2cdec35c/setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:80e177eff2d1ec172188d0d7fd9694f8e43d3aab76a6f5f929bee7bf7894e98b", size = 33963, upload-time = "2025-09-05T12:50:09.056Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/01/a36de7caf2d90c4c28678da1466b47495cbbad43badb4e982d8db8167ed4/setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:23e520776c445478a67ee71b2a3c1ffdafbe1f9f677239e03d7e2cc635954e18", size = 35550, upload-time = "2025-09-05T12:50:10.791Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/68/17e8aea0ed5ebc17fbf03ed2562bfab277c280e3625850c38d92a7b5fcd9/setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5fa1953126a3b9bd47049d58c51b9dac72e78ed120459bd3aceb1bacee72357c", size = 33727, upload-time = "2025-09-05T12:50:12.032Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/33/90a3bf43fe3a2242b4618aa799c672270250b5780667898f30663fd94993/setproctitle-1.3.7-cp313-cp313t-win32.whl", hash = "sha256:4a5e212bf438a4dbeece763f4962ad472c6008ff6702e230b4f16a037e2f6f29", size = 12549, upload-time = "2025-09-05T12:50:13.074Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/0e/50d1f07f3032e1f23d814ad6462bc0a138f369967c72494286b8a5228e40/setproctitle-1.3.7-cp313-cp313t-win_amd64.whl", hash = "sha256:cf2727b733e90b4f874bac53e3092aa0413fe1ea6d4f153f01207e6ce65034d9", size = 13243, upload-time = "2025-09-05T12:50:14.146Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c7/43ac3a98414f91d1b86a276bc2f799ad0b4b010e08497a95750d5bc42803/setproctitle-1.3.7-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:80c36c6a87ff72eabf621d0c79b66f3bdd0ecc79e873c1e9f0651ee8bf215c63", size = 18052, upload-time = "2025-09-05T12:50:17.928Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2c/dc258600a25e1a1f04948073826bebc55e18dbd99dc65a576277a82146fa/setproctitle-1.3.7-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b53602371a52b91c80aaf578b5ada29d311d12b8a69c0c17fbc35b76a1fd4f2e", size = 13071, upload-time = "2025-09-05T12:50:19.061Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/26/8e3bb082992f19823d831f3d62a89409deb6092e72fc6940962983ffc94f/setproctitle-1.3.7-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fcb966a6c57cf07cc9448321a08f3be6b11b7635be502669bc1d8745115d7e7f", size = 33180, upload-time = "2025-09-05T12:50:20.395Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/ae692a20276d1159dd0cf77b0bcf92cbb954b965655eb4a69672099bb214/setproctitle-1.3.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46178672599b940368d769474fe13ecef1b587d58bb438ea72b9987f74c56ea5", size = 34043, upload-time = "2025-09-05T12:50:22.454Z" },
+    { url = "https://files.pythonhosted.org/packages/34/b2/6a092076324dd4dac1a6d38482bedebbff5cf34ef29f58585ec76e47bc9d/setproctitle-1.3.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7f9e9e3ff135cbcc3edd2f4cf29b139f4aca040d931573102742db70ff428c17", size = 35892, upload-time = "2025-09-05T12:50:23.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/1a/8836b9f28cee32859ac36c3df85aa03e1ff4598d23ea17ca2e96b5845a8f/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:14c7eba8d90c93b0e79c01f0bd92a37b61983c27d6d7d5a3b5defd599113d60e", size = 32898, upload-time = "2025-09-05T12:50:25.617Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/22/8fabdc24baf42defb599714799d8445fe3ae987ec425a26ec8e80ea38f8e/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:9e64e98077fb30b6cf98073d6c439cd91deb8ebbf8fc62d9dbf52bd38b0c6ac0", size = 34308, upload-time = "2025-09-05T12:50:26.827Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/b9bee9de6c8cdcb3b3a6cb0b3e773afdb86bbbc1665a3bfa424a4294fda2/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b91387cc0f02a00ac95dcd93f066242d3cca10ff9e6153de7ee07069c6f0f7c8", size = 32536, upload-time = "2025-09-05T12:50:28.5Z" },
+    { url = "https://files.pythonhosted.org/packages/37/0c/75e5f2685a5e3eda0b39a8b158d6d8895d6daf3ba86dec9e3ba021510272/setproctitle-1.3.7-cp314-cp314-win32.whl", hash = "sha256:52b054a61c99d1b72fba58b7f5486e04b20fefc6961cd76722b424c187f362ed", size = 12731, upload-time = "2025-09-05T12:50:43.955Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/acddbce90d1361e1786e1fb421bc25baeb0c22ef244ee5d0176511769ec8/setproctitle-1.3.7-cp314-cp314-win_amd64.whl", hash = "sha256:5818e4080ac04da1851b3ec71e8a0f64e3748bf9849045180566d8b736702416", size = 13464, upload-time = "2025-09-05T12:50:45.057Z" },
+    { url = "https://files.pythonhosted.org/packages/01/6d/20886c8ff2e6d85e3cabadab6aab9bb90acaf1a5cfcb04d633f8d61b2626/setproctitle-1.3.7-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:6fc87caf9e323ac426910306c3e5d3205cd9f8dcac06d233fcafe9337f0928a3", size = 18062, upload-time = "2025-09-05T12:50:29.78Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/60/26dfc5f198715f1343b95c2f7a1c16ae9ffa45bd89ffd45a60ed258d24ea/setproctitle-1.3.7-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6134c63853d87a4897ba7d5cc0e16abfa687f6c66fc09f262bb70d67718f2309", size = 13075, upload-time = "2025-09-05T12:50:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/21/9c/980b01f50d51345dd513047e3ba9e96468134b9181319093e61db1c47188/setproctitle-1.3.7-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1403d2abfd32790b6369916e2313dffbe87d6b11dca5bbd898981bcde48e7a2b", size = 34744, upload-time = "2025-09-05T12:50:32.777Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b4/82cd0c86e6d1c4538e1a7eb908c7517721513b801dff4ba3f98ef816a240/setproctitle-1.3.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e7c5bfe4228ea22373e3025965d1a4116097e555ee3436044f5c954a5e63ac45", size = 35589, upload-time = "2025-09-05T12:50:34.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4f/9f6b2a7417fd45673037554021c888b31247f7594ff4bd2239918c5cd6d0/setproctitle-1.3.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:585edf25e54e21a94ccb0fe81ad32b9196b69ebc4fc25f81da81fb8a50cca9e4", size = 37698, upload-time = "2025-09-05T12:50:35.524Z" },
+    { url = "https://files.pythonhosted.org/packages/20/92/927b7d4744aac214d149c892cb5fa6dc6f49cfa040cb2b0a844acd63dcaf/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:96c38cdeef9036eb2724c2210e8d0b93224e709af68c435d46a4733a3675fee1", size = 34201, upload-time = "2025-09-05T12:50:36.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0c/fd4901db5ba4b9d9013e62f61d9c18d52290497f956745cd3e91b0d80f90/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:45e3ef48350abb49cf937d0a8ba15e42cee1e5ae13ca41a77c66d1abc27a5070", size = 35801, upload-time = "2025-09-05T12:50:38.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e3/54b496ac724e60e61cc3447f02690105901ca6d90da0377dffe49ff99fc7/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1fae595d032b30dab4d659bece20debd202229fce12b55abab978b7f30783d73", size = 33958, upload-time = "2025-09-05T12:50:39.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a8/c84bb045ebf8c6fdc7f7532319e86f8380d14bbd3084e6348df56bdfe6fd/setproctitle-1.3.7-cp314-cp314t-win32.whl", hash = "sha256:02432f26f5d1329ab22279ff863c83589894977063f59e6c4b4845804a08f8c2", size = 12745, upload-time = "2025-09-05T12:50:41.377Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b6/3a5a4f9952972791a9114ac01dfc123f0df79903577a3e0a7a404a695586/setproctitle-1.3.7-cp314-cp314t-win_amd64.whl", hash = "sha256:cbc388e3d86da1f766d8fc2e12682e446064c01cea9f88a88647cfe7c011de6a", size = 13469, upload-time = "2025-09-05T12:50:42.67Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This updates the Python SDK to the current kimi-cli and kosong pair, and it fixes the one SDK-side break that shows up with newer kimi-cli.

What changed
- bump `kimi-cli` from `1.12.x` to `1.37.x`
- bump `kosong` from `0.42.x` to `0.50.x`
- refresh `python/uv.lock`
- keep the SDK's existing `skills_dir` parameter working while adapting to newer `kimi-cli`, which now expects `skills_dirs`
- add coverage for the compatibility layer in `Session.create`, `Session.resume`, and the high-level `prompt(...)` API

Why the SDK-side fix is needed
Newer `kimi-cli` changed the `KimiCLI.create(...)` parameter from `skills_dir` to `skills_dirs`. Without an adapter here, the dependency bump breaks the Python SDK at runtime with:

`TypeError: KimiCLI.create() got an unexpected keyword argument 'skills_dir'`

This keeps the old SDK surface working and also allows the newer list-based form.

Validation
- `uv run --frozen pytest tests -q`
- `uv run --frozen pyright src tests`

Notes
- This keeps the Python SDK backward-compatible for current callers using `skills_dir=`.
- The lockfile also picks up the current transitive versions that come with `kimi-cli 1.37.0`, including `agent-client-protocol 0.8.0` and `pykaos 0.9.0`.
