### PR TITLE
fix(vscode-ext): slash command completion should insert instead of send

### DIFF
--- a/node/vscode_extension/webview-ui/src/components/inputarea/InputArea.tsx
+++ b/node/vscode_extension/webview-ui/src/components/inputarea/InputArea.tsx
@@ -154,8 +154,21 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
   });
 
   const handleSlashCommand = useMemoizedFn((name: string) => {
-    sendMessage(`/${name}`);
-    clearInput();
+    if (!activeToken) {
+      return;
+    }
+    const before = text.slice(0, activeToken.start);
+    const after = text.slice(cursorPos);
+    const newText = `${before}/${name} ${after}`;
+    const newCursorPos = activeToken.start + 1 + name.length + 1; // after the trailing space
+
+    setText(newText);
+    setCursorPos(newCursorPos);
+    setTimeout(() => {
+      textareaRef.current?.setSelectionRange(newCursorPos, newCursorPos);
+      textareaRef.current?.focus();
+      adjustHeight();
+    }, 0);
   });
 
   const applyMention = useMemoizedFn((filePath: string) => {


### PR DESCRIPTION
## Problem

When selecting a slash command via **Tab** or **Enter** from the completion menu in the VS Code extension, the command is immediately sent as a message and the input box is cleared. This prevents users from appending additional arguments or prompts after skills that accept parameters.

For example, with a skill like `/skill:speckit-specify`, users expect to auto-complete the skill name and then continue typing their specific prompt. The current behavior forces the skill to run without any user-supplied context.

## Root Cause

In `webview-ui/src/components/inputarea/InputArea.tsx`, the `handleSlashCommand` callback was calling `sendMessage()` and `clearInput()` directly upon selection, instead of inserting the command into the input box.

## Solution

Replace the "send-and-clear" logic with an "insert-and-focus" approach:
- Replace the active token text with the selected command name (e.g. `/skill:speckit-specify `)
- Position the cursor after the trailing space
- Keep focus on the textarea so the user can continue typing

This aligns the VS Code extension behavior with the CLI, where auto-completion only fills the command name without auto-executing it.

## Verification

- Built the webview-ui package successfully with `pnpm build`
- The change mirrors the existing `applyMention` pattern used for `@` file references, which also inserts into the input box rather than sending immediately

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
