### PR TITLE
feat(vscode): allow switching between built-in theme and inheriting VS Code theme

### DIFF
--- a/node/vscode_extension/package.json
+++ b/node/vscode_extension/package.json
@@ -102,6 +102,16 @@
             "Share when active file changes"
           ],
           "description": "Control when to share the active editor's file and cursor position with Kimi"
+        },
+        "kimi.themeMode": {
+          "type": "string",
+          "default": "builtin",
+          "enum": ["builtin", "vscode"],
+          "enumDescriptions": [
+            "Use the built-in Kimi Code theme",
+            "Inherit colors from the current VS Code theme"
+          ],
+          "description": "Select which theme to use for the Kimi Code UI"
         }
       }
     },

--- a/node/vscode_extension/shared/types.ts
+++ b/node/vscode_extension/shared/types.ts
@@ -38,6 +38,7 @@ export interface ExtensionConfig {
   environmentVariables: Record<string, string>;
   showThinkingContent: boolean;
   showThinkingExpanded: boolean;
+  themeMode: "builtin" | "vscode";
   version: string;
 }
 

--- a/node/vscode_extension/src/KimiWebviewProvider.ts
+++ b/node/vscode_extension/src/KimiWebviewProvider.ts
@@ -137,17 +137,19 @@ export class KimiWebviewProvider implements vscode.WebviewViewProvider {
   }
   .vscode-theme [data-variant="ghost"]:hover,
   .vscode-theme [data-variant="outline"]:hover {
-    background-color: color-mix(in oklch, var(--foreground) 20%, var(--background)) !important;
+    background-color: var(--vscode-toolbar-hoverBackground, var(--vscode-list-hoverBackground, color-mix(in oklch, var(--foreground) 20%, var(--background)))) !important;
   }
   .vscode-theme [data-plan-mode="inactive"]:hover {
-    background-color: color-mix(in oklch, var(--foreground) 20%, var(--background)) !important;
+    background-color: var(--vscode-toolbar-hoverBackground, var(--vscode-list-hoverBackground, color-mix(in oklch, var(--foreground) 20%, var(--background)))) !important;
   }
   .vscode-theme [data-slot="dropdown-menu-item"]:hover,
   .vscode-theme [data-slot="command-item"]:hover,
   .vscode-theme [data-slot="context-menu-item"]:hover,
-  .vscode-theme [data-session-item]:hover,
+  .vscode-theme [data-session-item]:hover {
+    background-color: var(--vscode-list-hoverBackground, color-mix(in oklch, var(--foreground) 20%, var(--background))) !important;
+  }
   .vscode-theme [data-block-header]:hover {
-    background-color: color-mix(in oklch, var(--foreground) 20%, var(--background)) !important;
+    background-color: var(--vscode-toolbar-hoverBackground, color-mix(in oklch, var(--foreground) 20%, var(--background))) !important;
   }
   .vscode-theme .border-border {
     border-color: transparent !important;

--- a/node/vscode_extension/src/KimiWebviewProvider.ts
+++ b/node/vscode_extension/src/KimiWebviewProvider.ts
@@ -1,5 +1,7 @@
 import * as vscode from "vscode";
+import * as fs from "fs";
 import { BridgeHandler } from "./bridge-handler";
+import { VSCodeSettings } from "./config/vscode-settings";
 
 interface RpcMessage {
   id: string;
@@ -123,6 +125,47 @@ export class KimiWebviewProvider implements vscode.WebviewViewProvider {
       `script-src 'nonce-${nonce}' ${webview.cspSource}`,
     ].join("; ");
 
+    const themeMode = VSCodeSettings.themeMode;
+
+    // Cache-bust the webview script so changes are picked up immediately
+    // during development (mtime changes on every rebuild).
+    const webviewJsPath = vscode.Uri.joinPath(this.extensionUri, "dist", "webview.js");
+    let cacheKey = "";
+    try {
+      cacheKey = `?v=${fs.statSync(webviewJsPath.fsPath).mtimeMs}`;
+    } catch {
+      // ignore - fallback to no cache-busting
+    }
+    const scriptUriWithCache = `${scriptUri.toString()}${cacheKey}`;
+
+    const vscodeThemeStyles = themeMode === "vscode"
+      ? `<style>
+  .vscode-theme [data-slot="button"] {
+    border: none !important;
+    box-shadow: none !important;
+    outline: none !important;
+    background-clip: border-box !important;
+  }
+  .vscode-theme [data-variant="ghost"]:hover,
+  .vscode-theme [data-variant="outline"]:hover {
+    background-color: color-mix(in oklch, var(--foreground) 20%, var(--background)) !important;
+  }
+  .vscode-theme [data-plan-mode="inactive"]:hover {
+    background-color: color-mix(in oklch, var(--foreground) 20%, var(--background)) !important;
+  }
+  .vscode-theme [data-slot="dropdown-menu-item"]:hover,
+  .vscode-theme [data-slot="command-item"]:hover,
+  .vscode-theme [data-slot="context-menu-item"]:hover,
+  .vscode-theme [data-session-item]:hover,
+  .vscode-theme [data-block-header]:hover {
+    background-color: color-mix(in oklch, var(--foreground) 20%, var(--background)) !important;
+  }
+  .vscode-theme .border-border {
+    border-color: transparent !important;
+  }
+</style>`
+      : "";
+
     return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -130,10 +173,11 @@ export class KimiWebviewProvider implements vscode.WebviewViewProvider {
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="${csp}">
   <title>Kimi Code</title>
+  ${vscodeThemeStyles}
 </head>
-<body data-baseuri="${baseUri}" data-webviewid="${webviewId}">
+<body data-baseuri="${baseUri}" data-webviewid="${webviewId}" data-thememode="${themeMode}">
   <div id="root"></div>
-  <script nonce="${nonce}" src="${scriptUri}"></script>
+  <script nonce="${nonce}" src="${scriptUriWithCache}"></script>
 </body>
 </html>`;
   }

--- a/node/vscode_extension/src/KimiWebviewProvider.ts
+++ b/node/vscode_extension/src/KimiWebviewProvider.ts
@@ -127,17 +127,6 @@ export class KimiWebviewProvider implements vscode.WebviewViewProvider {
 
     const themeMode = VSCodeSettings.themeMode;
 
-    // Cache-bust the webview script so changes are picked up immediately
-    // during development (mtime changes on every rebuild).
-    const webviewJsPath = vscode.Uri.joinPath(this.extensionUri, "dist", "webview.js");
-    let cacheKey = "";
-    try {
-      cacheKey = `?v=${fs.statSync(webviewJsPath.fsPath).mtimeMs}`;
-    } catch {
-      // ignore - fallback to no cache-busting
-    }
-    const scriptUriWithCache = `${scriptUri.toString()}${cacheKey}`;
-
     const vscodeThemeStyles = themeMode === "vscode"
       ? `<style>
   .vscode-theme [data-slot="button"] {
@@ -177,7 +166,7 @@ export class KimiWebviewProvider implements vscode.WebviewViewProvider {
 </head>
 <body data-baseuri="${baseUri}" data-webviewid="${webviewId}" data-thememode="${themeMode}">
   <div id="root"></div>
-  <script nonce="${nonce}" src="${scriptUriWithCache}"></script>
+  <script nonce="${nonce}" src="${scriptUri}"></script>
 </body>
 </html>`;
   }

--- a/node/vscode_extension/src/config/vscode-settings.ts
+++ b/node/vscode_extension/src/config/vscode-settings.ts
@@ -45,6 +45,10 @@ export const VSCodeSettings = {
     return getConfig().get<"never" | "onConversationStart" | "onFileChange">("editorContext", "never");
   },
 
+  get themeMode(): "builtin" | "vscode" {
+    return getConfig().get<"builtin" | "vscode">("themeMode", "builtin");
+  },
+
   getExtensionConfig(): ExtensionConfig {
     return {
       executablePath: this.executablePath,
@@ -55,6 +59,7 @@ export const VSCodeSettings = {
       environmentVariables: this.environmentVariables,
       showThinkingContent: this.showThinkingContent,
       showThinkingExpanded: this.showThinkingExpanded,
+      themeMode: this.themeMode,
       version: EXTENSION_VERSION,
     };
   },
@@ -65,7 +70,7 @@ export function onSettingsChange(callback: (changedKeys: string[]) => void): vsc
     if (!e.affectsConfiguration("kimi")) {
       return;
     }
-    const keys = ["yoloMode", "autosave", "executablePath", "enableNewConversationShortcut", "useCtrlEnterToSend", "environmentVariables", "showThinkingContent", "showThinkingExpanded", "editorContext"];
+    const keys = ["yoloMode", "autosave", "executablePath", "enableNewConversationShortcut", "useCtrlEnterToSend", "environmentVariables", "showThinkingContent", "showThinkingExpanded", "editorContext", "themeMode"];
     const changedKeys = keys.filter((key) => e.affectsConfiguration(`kimi.${key}`));
     if (changedKeys.length > 0) {
       callback(changedKeys);

--- a/node/vscode_extension/webview-ui/src/App.tsx
+++ b/node/vscode_extension/webview-ui/src/App.tsx
@@ -58,6 +58,11 @@ function MainContent({ onAuthAction }: { onAuthAction: () => void }) {
     return () => window.removeEventListener("keydown", handler);
   }, [extensionConfig.enableNewConversationShortcut, startNewConversation]);
 
+  useEffect(() => {
+    document.body.setAttribute("data-thememode", extensionConfig.themeMode ?? "builtin");
+    document.documentElement.classList.toggle("vscode-theme", extensionConfig.themeMode === "vscode");
+  }, [extensionConfig.themeMode]);
+
   return (
     <>
       <div className="flex-1 min-h-0 relative group/chat">

--- a/node/vscode_extension/webview-ui/src/components/ChatMessage.tsx
+++ b/node/vscode_extension/webview-ui/src/components/ChatMessage.tsx
@@ -37,7 +37,7 @@ function SteerBubble({ content }: { content: string | import("@moonshot-ai/kimi-
   const text = typeof content === "string" ? content : Content.getText(content);
   return (
     <div className="flex justify-end my-1">
-      <div className="max-w-[85%] px-3 py-1 rounded-2xl rounded-br-md bg-zinc-100 dark:bg-zinc-800 text-foreground">
+      <div className="max-w-[85%] px-3 py-1 rounded-2xl rounded-br-md bg-muted text-foreground">
         <p className="text-xs leading-relaxed">{text}</p>
       </div>
     </div>
@@ -221,7 +221,7 @@ function UserMessage({ message }: { message: ChatMessageType }) {
 
   return (
     <div className="px-3 pt-3 pb-1 flex justify-end">
-      <div className={cn("max-w-[85%] px-3.5 py-1.5 rounded-2xl rounded-br-md", "bg-zinc-100 dark:bg-zinc-800", "text-foreground")}>
+      <div className={cn("max-w-[85%] px-3.5 py-1.5 rounded-2xl rounded-br-md", "bg-muted", "text-foreground")}>
         {displayContent && (
           // FIX: removed whitespace-pre-wrap — it conflicted with ReactMarkdown's
           // block-level elements (<p>, <ol>, <li>), doubling vertical spacing.

--- a/node/vscode_extension/webview-ui/src/components/ChatMessage.tsx
+++ b/node/vscode_extension/webview-ui/src/components/ChatMessage.tsx
@@ -37,7 +37,7 @@ function SteerBubble({ content }: { content: string | import("@moonshot-ai/kimi-
   const text = typeof content === "string" ? content : Content.getText(content);
   return (
     <div className="flex justify-end my-1">
-      <div className="max-w-[85%] px-3 py-1 rounded-2xl rounded-br-md bg-muted text-foreground">
+      <div className="max-w-[85%] px-3 py-1 rounded-2xl rounded-br-md bg-zinc-100 dark:bg-zinc-800 text-foreground steer-bubble">
         <p className="text-xs leading-relaxed">{text}</p>
       </div>
     </div>
@@ -221,7 +221,7 @@ function UserMessage({ message }: { message: ChatMessageType }) {
 
   return (
     <div className="px-3 pt-3 pb-1 flex justify-end">
-      <div className={cn("max-w-[85%] px-3.5 py-1.5 rounded-2xl rounded-br-md", "bg-muted", "text-foreground")}>
+      <div className={cn("max-w-[85%] px-3.5 py-1.5 rounded-2xl rounded-br-md", "bg-zinc-100 dark:bg-zinc-800", "text-foreground user-message-bubble")}>
         {displayContent && (
           // FIX: removed whitespace-pre-wrap — it conflicted with ReactMarkdown's
           // block-level elements (<p>, <ol>, <li>), doubling vertical spacing.

--- a/node/vscode_extension/webview-ui/src/components/ChatStatus.tsx
+++ b/node/vscode_extension/webview-ui/src/components/ChatStatus.tsx
@@ -61,7 +61,7 @@ export function ChatStatus() {
   const contextPercent = context_usage ? Math.round(context_usage * 1000) / 10 : 0;
 
   return (
-    <div className="flex items-center gap-3 text-[10px] text-muted-foreground border border-[var(--border)] rounded-full px-2 py-0.5 select-none h-6 box-border mr-2 @max-[240px]:hidden">
+    <div className="flex items-center gap-3 text-[10px] text-muted-foreground border border-border/40 rounded-full px-2 py-0.5 select-none h-6 box-border mr-2 @max-[240px]:hidden chat-status-bar">
       <div className="flex items-center gap-1.5" title="Context Window Usage">
         <Tooltip>
           <TooltipTrigger asChild>

--- a/node/vscode_extension/webview-ui/src/components/ChatStatus.tsx
+++ b/node/vscode_extension/webview-ui/src/components/ChatStatus.tsx
@@ -61,7 +61,7 @@ export function ChatStatus() {
   const contextPercent = context_usage ? Math.round(context_usage * 1000) / 10 : 0;
 
   return (
-    <div className="flex items-center gap-3 text-[10px] text-muted-foreground border border-border/40 rounded-full px-2 py-0.5 select-none h-6 box-border mr-2 @max-[240px]:hidden">
+    <div className="flex items-center gap-3 text-[10px] text-muted-foreground border border-[var(--border)] rounded-full px-2 py-0.5 select-none h-6 box-border mr-2 @max-[240px]:hidden">
       <div className="flex items-center gap-1.5" title="Context Window Usage">
         <Tooltip>
           <TooltipTrigger asChild>

--- a/node/vscode_extension/webview-ui/src/components/PlanModeButton.tsx
+++ b/node/vscode_extension/webview-ui/src/components/PlanModeButton.tsx
@@ -16,6 +16,7 @@ export function PlanModeButton({ active, onToggle }: PlanModeButtonProps) {
         <button
           type="button"
           onClick={onToggle}
+          data-plan-mode={active ? "active" : "inactive"}
           className={cn(
             "flex items-center justify-center size-6 rounded-md transition-all cursor-pointer",
             active

--- a/node/vscode_extension/webview-ui/src/components/SessionList.tsx
+++ b/node/vscode_extension/webview-ui/src/components/SessionList.tsx
@@ -39,6 +39,7 @@ function SessionItem({ session, isSelected, onSelect, onDelete, dirLabel }: Sess
 
   return (
     <div
+      data-session-item
       className={cn("group relative px-2 py-1 rounded-md cursor-pointer transition-colors", isSelected ? "bg-accent" : "hover:bg-accent/50")}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}

--- a/node/vscode_extension/webview-ui/src/components/ThinkingBlock.tsx
+++ b/node/vscode_extension/webview-ui/src/components/ThinkingBlock.tsx
@@ -20,14 +20,14 @@ export function ThinkingBlock({ content, finished, compact }: ThinkingBlockProps
   if (!showThinkingContent) {
     // Hidden mode: static label, no interaction
     return (
-      <div className="rounded-lg bg-input overflow-hidden">
+      <div className="rounded-lg border border-zinc-200/50 bg-zinc-50/30 dark:border-zinc-800/50 dark:bg-zinc-900/10 overflow-hidden thinking-block">
         <div
           className={cn("w-full flex items-center gap-2", compact ? "px-2 py-1.5" : "px-3 py-2")}
         >
           <div className="inline-flex items-center gap-2">
-            <IconBulb className={cn("text-muted-foreground", compact ? "size-3" : "size-3.5")} />
-            <span className={cn("font-medium text-foreground", compact ? "text-[0.75rem]" : "text-xs")}>Thinking</span>
-            {isStreaming && <IconLoader3 className={cn("text-muted-foreground ml-auto animate-spin", compact ? "size-3" : "size-3.5")} />}
+            <IconBulb className={cn("text-zinc-500", compact ? "size-3" : "size-3.5")} />
+            <span className={cn("font-medium text-zinc-700 dark:text-zinc-300", compact ? "text-[0.75rem]" : "text-xs")}>Thinking</span>
+            {isStreaming && <IconLoader3 className={cn("text-zinc-400 ml-auto animate-spin", compact ? "size-3" : "size-3.5")} />}
           </div>
         </div>
       </div>
@@ -40,24 +40,24 @@ export function ThinkingBlock({ content, finished, compact }: ThinkingBlockProps
   }
 
   return (
-    <div className="rounded-lg bg-input overflow-hidden">
+    <div className="rounded-lg border border-zinc-200/50 bg-zinc-50/30 dark:border-zinc-800/50 dark:bg-zinc-900/10 overflow-hidden thinking-block">
       <button
         onClick={() => setExpanded(!expanded)}
         data-block-header="thinking"
-        className={cn("w-full flex items-center gap-2 hover:bg-muted/50 transition-colors", compact ? "px-2 py-1.5" : "px-3 py-2")}
+        className={cn("w-full flex items-center gap-2 hover:bg-zinc-100/50 dark:hover:bg-zinc-800/20 transition-colors", compact ? "px-2 py-1.5" : "px-3 py-2")}
       >
         <div className="inline-flex items-center gap-2">
-          <IconBulb className={cn("text-muted-foreground", compact ? "size-3" : "size-3.5")} />
-          <span className={cn("font-medium text-foreground", compact ? "text-[0.75rem]" : "text-xs")}>Thinking</span>
-          {isStreaming && <IconLoader3 className={cn("text-muted-foreground ml-auto animate-spin", compact ? "size-3" : "size-3.5")} />}
+          <IconBulb className={cn("text-zinc-500", compact ? "size-3" : "size-3.5")} />
+          <span className={cn("font-medium text-zinc-700 dark:text-zinc-300", compact ? "text-[0.75rem]" : "text-xs")}>Thinking</span>
+          {isStreaming && <IconLoader3 className={cn("text-zinc-400 ml-auto animate-spin", compact ? "size-3" : "size-3.5")} />}
         </div>
-        <IconChevronDown className={cn("text-muted-foreground ml-auto transition-transform", compact ? "size-3" : "size-3.5", expanded && "rotate-180")} />
+        <IconChevronDown className={cn("text-zinc-400 ml-auto transition-transform", compact ? "size-3" : "size-3.5", expanded && "rotate-180")} />
       </button>
 
       {expanded && content && (
         <Markdown
           content={content}
-          className={cn("border-t border-[var(--border)]", compact ? "py-2 px-2 text-[0.75rem]" : "py-3 px-2 pl-3.5 text-xs")}
+          className={cn("border-t border-zinc-200/50 dark:border-zinc-700/50", compact ? "py-2 px-2 text-[0.75rem]" : "py-3 px-2 pl-3.5 text-xs")}
           enableEnrichment={finished}
         />
       )}

--- a/node/vscode_extension/webview-ui/src/components/ThinkingBlock.tsx
+++ b/node/vscode_extension/webview-ui/src/components/ThinkingBlock.tsx
@@ -20,14 +20,14 @@ export function ThinkingBlock({ content, finished, compact }: ThinkingBlockProps
   if (!showThinkingContent) {
     // Hidden mode: static label, no interaction
     return (
-      <div className="rounded-lg border border-zinc-200/50 bg-zinc-50/30 dark:border-zinc-800/50 dark:bg-zinc-900/10 overflow-hidden">
+      <div className="rounded-lg bg-input overflow-hidden">
         <div
           className={cn("w-full flex items-center gap-2", compact ? "px-2 py-1.5" : "px-3 py-2")}
         >
           <div className="inline-flex items-center gap-2">
-            <IconBulb className={cn("text-zinc-500", compact ? "size-3" : "size-3.5")} />
-            <span className={cn("font-medium text-zinc-700 dark:text-zinc-300", compact ? "text-[0.75rem]" : "text-xs")}>Thinking</span>
-            {isStreaming && <IconLoader3 className={cn("text-zinc-400 ml-auto animate-spin", compact ? "size-3" : "size-3.5")} />}
+            <IconBulb className={cn("text-muted-foreground", compact ? "size-3" : "size-3.5")} />
+            <span className={cn("font-medium text-foreground", compact ? "text-[0.75rem]" : "text-xs")}>Thinking</span>
+            {isStreaming && <IconLoader3 className={cn("text-muted-foreground ml-auto animate-spin", compact ? "size-3" : "size-3.5")} />}
           </div>
         </div>
       </div>
@@ -40,23 +40,24 @@ export function ThinkingBlock({ content, finished, compact }: ThinkingBlockProps
   }
 
   return (
-    <div className="rounded-lg border border-zinc-200/50 bg-zinc-50/30 dark:border-zinc-800/50 dark:bg-zinc-900/10 overflow-hidden">
+    <div className="rounded-lg bg-input overflow-hidden">
       <button
         onClick={() => setExpanded(!expanded)}
-        className={cn("w-full flex items-center gap-2 hover:bg-zinc-100/50 dark:hover:bg-zinc-800/20 transition-colors", compact ? "px-2 py-1.5" : "px-3 py-2")}
+        data-block-header="thinking"
+        className={cn("w-full flex items-center gap-2 hover:bg-muted/50 transition-colors", compact ? "px-2 py-1.5" : "px-3 py-2")}
       >
         <div className="inline-flex items-center gap-2">
-          <IconBulb className={cn("text-zinc-500", compact ? "size-3" : "size-3.5")} />
-          <span className={cn("font-medium text-zinc-700 dark:text-zinc-300", compact ? "text-[0.75rem]" : "text-xs")}>Thinking</span>
-          {isStreaming && <IconLoader3 className={cn("text-zinc-400 ml-auto animate-spin", compact ? "size-3" : "size-3.5")} />}
+          <IconBulb className={cn("text-muted-foreground", compact ? "size-3" : "size-3.5")} />
+          <span className={cn("font-medium text-foreground", compact ? "text-[0.75rem]" : "text-xs")}>Thinking</span>
+          {isStreaming && <IconLoader3 className={cn("text-muted-foreground ml-auto animate-spin", compact ? "size-3" : "size-3.5")} />}
         </div>
-        <IconChevronDown className={cn("text-zinc-400 ml-auto transition-transform", compact ? "size-3" : "size-3.5", expanded && "rotate-180")} />
+        <IconChevronDown className={cn("text-muted-foreground ml-auto transition-transform", compact ? "size-3" : "size-3.5", expanded && "rotate-180")} />
       </button>
 
       {expanded && content && (
         <Markdown
           content={content}
-          className={cn("border-t border-zinc-200/50 dark:border-zinc-700/50", compact ? "py-2 px-2 text-[0.75rem]" : "py-3 px-2 pl-3.5 text-xs")}
+          className={cn("border-t border-[var(--border)]", compact ? "py-2 px-2 text-[0.75rem]" : "py-3 px-2 pl-3.5 text-xs")}
           enableEnrichment={finished}
         />
       )}

--- a/node/vscode_extension/webview-ui/src/components/ToolRenderers.tsx
+++ b/node/vscode_extension/webview-ui/src/components/ToolRenderers.tsx
@@ -432,7 +432,7 @@ export function ToolCallCard({ call, result, subagentSteps }: ToolRendererProps)
   };
 
   return (
-    <div className="rounded-lg bg-input overflow-hidden">
+    <div className="rounded-lg border border-border overflow-hidden tool-call-card">
       <button onClick={() => setExpanded(!expanded)} data-block-header="tool" className="w-full flex items-center gap-2 px-3 py-2 hover:bg-muted/50 transition-colors">
         <StatusIndicator status={status} />
         <ToolIcon name={call.name} />
@@ -441,7 +441,7 @@ export function ToolCallCard({ call, result, subagentSteps }: ToolRendererProps)
         {subagentSteps && subagentSteps.length > 0 && <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-500">{subagentSteps.length} steps</span>}
         <IconChevronDown className={cn("size-3.5 text-muted-foreground transition-transform", expanded && "rotate-180")} />
       </button>
-      {expanded && <div className="@container px-3 py-0.5 border-t border-border/50">{renderContent()}</div>}
+      {expanded && <div className="@container px-3 py-0.5 border-t border-border">{renderContent()}</div>}
     </div>
   );
 }

--- a/node/vscode_extension/webview-ui/src/components/ToolRenderers.tsx
+++ b/node/vscode_extension/webview-ui/src/components/ToolRenderers.tsx
@@ -432,8 +432,8 @@ export function ToolCallCard({ call, result, subagentSteps }: ToolRendererProps)
   };
 
   return (
-    <div className="rounded-lg border border-border overflow-hidden">
-      <button onClick={() => setExpanded(!expanded)} className="w-full flex items-center gap-2 px-3 py-2 hover:bg-muted/50 transition-colors">
+    <div className="rounded-lg bg-input overflow-hidden">
+      <button onClick={() => setExpanded(!expanded)} data-block-header="tool" className="w-full flex items-center gap-2 px-3 py-2 hover:bg-muted/50 transition-colors">
         <StatusIndicator status={status} />
         <ToolIcon name={call.name} />
         <span className="text-xs font-medium">{call.name}</span>
@@ -441,7 +441,7 @@ export function ToolCallCard({ call, result, subagentSteps }: ToolRendererProps)
         {subagentSteps && subagentSteps.length > 0 && <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-500">{subagentSteps.length} steps</span>}
         <IconChevronDown className={cn("size-3.5 text-muted-foreground transition-transform", expanded && "rotate-180")} />
       </button>
-      {expanded && <div className="@container px-3 py-0.5 border-t border-border">{renderContent()}</div>}
+      {expanded && <div className="@container px-3 py-0.5 border-t border-border/50">{renderContent()}</div>}
     </div>
   );
 }

--- a/node/vscode_extension/webview-ui/src/components/ToolRenderers.tsx
+++ b/node/vscode_extension/webview-ui/src/components/ToolRenderers.tsx
@@ -67,15 +67,15 @@ function CodeBlock({ content, maxLines = 10 }: { content: string; maxLines?: num
   const displayContent = shouldCollapse && !expanded ? lines.slice(0, maxLines).join("\n") : content;
 
   return (
-    <div className="relative group/codeblock">
-      <pre className="text-[11px] bg-muted text-muted-foreground rounded px-3 py-2 overflow-x-auto whitespace-pre-wrap break-all">
+    <div className="relative group/codeblock tool-codeblock">
+      <pre className="text-[11px] bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 rounded px-3 py-2 overflow-x-auto whitespace-pre-wrap break-all">
         {displayContent}
-        {shouldCollapse && !expanded && <span className="text-muted-foreground">{"\n"}...</span>}
+        {shouldCollapse && !expanded && <span className="text-zinc-500">{"\n"}...</span>}
       </pre>
       {shouldCollapse && (
         <button
           onClick={() => setExpanded(!expanded)}
-          className="absolute bottom-1.5 right-1.5 text-[11px] px-1.5 py-0.5 rounded bg-popover border border-border text-muted-foreground hover:text-foreground opacity-0 group-hover/codeblock:opacity-100 transition-opacity cursor-pointer"
+          className="codeblock-expand absolute bottom-1.5 right-1.5 text-[11px] px-1.5 py-0.5 rounded bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 opacity-0 group-hover/codeblock:opacity-100 transition-opacity cursor-pointer"
         >
           {expanded ? "Less" : `Expand +${lines.length - maxLines}`}
         </button>
@@ -130,15 +130,15 @@ function IORow({ label, children }: { label: "IN" | "OUT"; children: React.React
 function TodoStatusIcon({ status }: { status: string }) {
   if (status === "done") {
     return (
-      <div className="size-4 rounded flex items-center justify-center">
-        <IconSquareCheck className="size-3 text-muted-foreground" />
+      <div data-todo-status="done" className="size-4 rounded flex items-center justify-center">
+        <IconSquareCheck className="size-3 text-zinc-600 dark:text-zinc-400" />
       </div>
     );
   }
   if (status === "in_progress") {
     return <IconSquareChevronRight className="size-4 text-amber-500" />;
   }
-  return <IconSquare className="size-4 text-muted-foreground" />;
+  return <IconSquare data-todo-status="empty" className="size-4 text-zinc-300 dark:text-zinc-600" />;
 }
 
 function SetTodoListTool({ result }: ToolRendererProps) {

--- a/node/vscode_extension/webview-ui/src/components/ToolRenderers.tsx
+++ b/node/vscode_extension/webview-ui/src/components/ToolRenderers.tsx
@@ -68,14 +68,14 @@ function CodeBlock({ content, maxLines = 10 }: { content: string; maxLines?: num
 
   return (
     <div className="relative group/codeblock">
-      <pre className="text-[11px] bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 rounded px-3 py-2 overflow-x-auto whitespace-pre-wrap break-all">
+      <pre className="text-[11px] bg-muted text-muted-foreground rounded px-3 py-2 overflow-x-auto whitespace-pre-wrap break-all">
         {displayContent}
-        {shouldCollapse && !expanded && <span className="text-zinc-500">{"\n"}...</span>}
+        {shouldCollapse && !expanded && <span className="text-muted-foreground">{"\n"}...</span>}
       </pre>
       {shouldCollapse && (
         <button
           onClick={() => setExpanded(!expanded)}
-          className="absolute bottom-1.5 right-1.5 text-[11px] px-1.5 py-0.5 rounded bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 opacity-0 group-hover/codeblock:opacity-100 transition-opacity cursor-pointer"
+          className="absolute bottom-1.5 right-1.5 text-[11px] px-1.5 py-0.5 rounded bg-popover border border-border text-muted-foreground hover:text-foreground opacity-0 group-hover/codeblock:opacity-100 transition-opacity cursor-pointer"
         >
           {expanded ? "Less" : `Expand +${lines.length - maxLines}`}
         </button>
@@ -131,14 +131,14 @@ function TodoStatusIcon({ status }: { status: string }) {
   if (status === "done") {
     return (
       <div className="size-4 rounded flex items-center justify-center">
-        <IconSquareCheck className="size-3 text-zinc-600 dark:text-zinc-400" />
+        <IconSquareCheck className="size-3 text-muted-foreground" />
       </div>
     );
   }
   if (status === "in_progress") {
     return <IconSquareChevronRight className="size-4 text-amber-500" />;
   }
-  return <IconSquare className="size-4 text-zinc-300 dark:text-zinc-600" />;
+  return <IconSquare className="size-4 text-muted-foreground" />;
 }
 
 function SetTodoListTool({ result }: ToolRendererProps) {

--- a/node/vscode_extension/webview-ui/src/components/inputarea/InputArea.tsx
+++ b/node/vscode_extension/webview-ui/src/components/inputarea/InputArea.tsx
@@ -337,7 +337,7 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
           </div>
         )}
 
-        <div className="bg-input rounded-md overflow-hidden">
+        <div className="border border-input rounded-md overflow-hidden input-area-wrapper">
           {draftMedia.length > 0 && (
             <div className="flex gap-2 p-2 overflow-x-auto">
               {draftMedia.map((item) => (

--- a/node/vscode_extension/webview-ui/src/components/inputarea/InputArea.tsx
+++ b/node/vscode_extension/webview-ui/src/components/inputarea/InputArea.tsx
@@ -337,7 +337,7 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
           </div>
         )}
 
-        <div className="border border-input rounded-md overflow-hidden">
+        <div className="bg-input rounded-md overflow-hidden">
           {draftMedia.length > 0 && (
             <div className="flex gap-2 p-2 overflow-x-auto">
               {draftMedia.map((item) => (

--- a/node/vscode_extension/webview-ui/src/components/ui/button.tsx
+++ b/node/vscode_extension/webview-ui/src/components/ui/button.tsx
@@ -11,9 +11,9 @@ const buttonVariants = cva(
       variant: {
         default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
         outline:
-          "border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input aria-expanded:bg-muted aria-expanded:text-foreground",
+          "border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
-        ghost: "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground",
+        ghost: "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground",
         destructive:
           "bg-destructive/10 hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/20 text-destructive focus-visible:border-destructive/40 dark:hover:bg-destructive/30",
         link: "text-primary underline-offset-4 hover:underline",

--- a/node/vscode_extension/webview-ui/src/components/ui/button.tsx
+++ b/node/vscode_extension/webview-ui/src/components/ui/button.tsx
@@ -11,9 +11,9 @@ const buttonVariants = cva(
       variant: {
         default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
         outline:
-          "border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground",
+          "border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input aria-expanded:bg-muted aria-expanded:text-foreground",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
-        ghost: "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground",
+        ghost: "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground",
         destructive:
           "bg-destructive/10 hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/20 text-destructive focus-visible:border-destructive/40 dark:hover:bg-destructive/30",
         link: "text-primary underline-offset-4 hover:underline",

--- a/node/vscode_extension/webview-ui/src/main.tsx
+++ b/node/vscode_extension/webview-ui/src/main.tsx
@@ -7,12 +7,21 @@ function syncTheme() {
   document.documentElement.classList.toggle("dark", isDark);
 }
 
-syncTheme();
+function syncThemeMode() {
+  const themeMode = document.body.getAttribute("data-thememode") ?? "builtin";
+  document.documentElement.classList.toggle("vscode-theme", themeMode === "vscode");
+}
 
-const observer = new MutationObserver(syncTheme);
+syncTheme();
+syncThemeMode();
+
+const observer = new MutationObserver(() => {
+  syncTheme();
+  syncThemeMode();
+});
 observer.observe(document.body, {
   attributes: true,
-  attributeFilter: ["class"],
+  attributeFilter: ["class", "data-thememode"],
 });
 
 const container = document.getElementById("root");

--- a/node/vscode_extension/webview-ui/src/stores/settings.store.ts
+++ b/node/vscode_extension/webview-ui/src/stores/settings.store.ts
@@ -12,6 +12,7 @@ export const DEFAULT_EXTENSION_CONFIG: ExtensionConfig = {
   environmentVariables: {},
   showThinkingContent: true,
   showThinkingExpanded: true,
+  themeMode: "builtin",
   version: "",
 };
 

--- a/node/vscode_extension/webview-ui/src/styles/index.css
+++ b/node/vscode_extension/webview-ui/src/styles/index.css
@@ -149,22 +149,29 @@ body {
    We target by data-variant directly in case data-slot is stripped by Radix Slot. */
 .vscode-theme [data-variant="ghost"]:hover,
 .vscode-theme [data-variant="outline"]:hover {
-  background-color: color-mix(in oklch, var(--foreground) 20%, var(--background));
+  background-color: var(--vscode-toolbar-hoverBackground, var(--vscode-list-hoverBackground, color-mix(in oklch, var(--foreground) 20%, var(--background))));
 }
 
 /* Plan mode button (custom component, not shadcn Button) */
 .vscode-theme [data-plan-mode="inactive"]:hover {
-  background-color: color-mix(in oklch, var(--foreground) 20%, var(--background));
+  background-color: var(--vscode-toolbar-hoverBackground, var(--vscode-list-hoverBackground, color-mix(in oklch, var(--foreground) 20%, var(--background))));
 }
 
-/* Menu items: use a solid hover tint instead of the accent color which often
-   clashes with dark VSCode themes. */
+/* Menu items, list items: use the exact VSCode list hover background that
+   native menus and trees use. */
 .vscode-theme [data-slot="dropdown-menu-item"]:hover,
 .vscode-theme [data-slot="command-item"]:hover,
 .vscode-theme [data-slot="context-menu-item"]:hover,
-.vscode-theme [data-session-item]:hover,
+.vscode-theme [data-session-item]:hover {
+  background-color: var(--vscode-list-hoverBackground, color-mix(in oklch, var(--foreground) 20%, var(--background)));
+}
+
+/* Block headers (thinking, tool cards): use toolbar hover background.
+   list.hoverBackground is often transparent in minimal themes, which makes
+   custom interactive headers feel broken. Toolbar hover is consistently
+   visible because icon buttons need clear feedback. */
 .vscode-theme [data-block-header]:hover {
-  background-color: color-mix(in oklch, var(--foreground) 20%, var(--background));
+  background-color: var(--vscode-toolbar-hoverBackground, color-mix(in oklch, var(--foreground) 20%, var(--background)));
 }
 
 /* Remove bright borders from common UI elements in VSCode theme mode when
@@ -178,12 +185,10 @@ body {
 
 .vscode-theme ::-webkit-scrollbar-thumb {
   background: var(--vscode-scrollbarSlider-background, var(--vscode-descriptionForeground, var(--muted-foreground)));
-  opacity: 0.4;
 }
 
 .vscode-theme ::-webkit-scrollbar-thumb:hover {
   background: var(--vscode-scrollbarSlider-hoverBackground, var(--vscode-descriptionForeground, var(--muted-foreground)));
-  opacity: 0.6;
 }
 
 /* Component overrides for VSCode theme — revert-safe: these classes are
@@ -203,10 +208,6 @@ body {
 .vscode-theme .thinking-block .text-zinc-700,
 .vscode-theme .thinking-block .text-zinc-300 {
   color: var(--foreground);
-}
-
-.vscode-theme .thinking-block [data-block-header]:hover {
-  background-color: color-mix(in oklch, var(--foreground) 20%, var(--background));
 }
 
 .vscode-theme .thinking-block > .border-t {
@@ -229,15 +230,13 @@ body {
   border-color: transparent !important;
 }
 
-/* User message bubbles: muted background */
+/* User message bubbles: use the exact VSCode chat request bubble
+   colours that Copilot Chat uses.  These variables are injected by
+   VSCode into every webview when the theme defines them. */
 .vscode-theme .user-message-bubble,
 .vscode-theme .steer-bubble {
-  background-color: var(--muted) !important;
-}
-
-/* Chat status bar: use theme border */
-.vscode-theme .chat-status-bar {
-  border-color: color-mix(in oklch, var(--border) 40%, transparent) !important;
+  background-color: var(--vscode-chat-requestBubbleBackground, var(--vscode-chat-requestBackground, var(--vscode-input-background))) !important;
+  color: var(--vscode-chat-requestForeground, var(--vscode-foreground));
 }
 
 ::-webkit-scrollbar {

--- a/node/vscode_extension/webview-ui/src/styles/index.css
+++ b/node/vscode_extension/webview-ui/src/styles/index.css
@@ -49,10 +49,6 @@
   --ring: oklch(0.552 0.016 285.938);
 }
 
-* {
-  border-color: var(--border);
-}
-
 html,
 body {
   margin: 0;
@@ -106,9 +102,88 @@ body {
   * {
     @apply border-border;
   }
+  :where(.vscode-theme) * {
+    border-color: transparent;
+  }
   body {
     @apply bg-background text-foreground font-sans antialiased;
   }
+}
+
+.vscode-theme {
+  --background: var(--vscode-panel-background, var(--vscode-editor-background, oklch(1 0 0)));
+  --foreground: var(--vscode-panel-foreground, var(--vscode-editor-foreground, oklch(0.141 0.005 285.823)));
+  --card: var(--vscode-input-background, var(--vscode-dropdown-background, var(--vscode-panel-background, oklch(1 0 0))));
+  --card-foreground: var(--vscode-input-foreground, var(--vscode-dropdown-foreground, var(--vscode-panel-foreground, oklch(0.141 0.005 285.823))));
+  --popover: var(--vscode-dropdown-background, var(--vscode-input-background, var(--vscode-panel-background, oklch(1 0 0))));
+  --popover-foreground: var(--vscode-dropdown-foreground, var(--vscode-input-foreground, var(--vscode-panel-foreground, oklch(0.141 0.005 285.823))));
+  --primary: var(--vscode-button-background, oklch(0.21 0.006 285.885));
+  --primary-foreground: var(--vscode-button-foreground, oklch(1 0 0));
+  --secondary: var(--vscode-button-secondaryBackground, var(--vscode-list-hoverBackground, var(--vscode-input-background, oklch(0.967 0.001 286.375))));
+  --secondary-foreground: var(--vscode-button-secondaryForeground, var(--vscode-editor-foreground, oklch(0.21 0.006 285.885)));
+  --muted: var(--vscode-list-hoverBackground, var(--vscode-input-background, var(--vscode-panel-background, oklch(0.967 0.001 286.375))));
+  --muted-foreground: var(--vscode-descriptionForeground, var(--vscode-panel-foreground, oklch(0.552 0.016 285.938)));
+  --accent: var(--vscode-list-hoverBackground, var(--vscode-input-background, var(--vscode-panel-background, oklch(0.967 0.001 286.375))));
+  --accent-foreground: var(--vscode-editor-foreground, oklch(0.21 0.006 285.885));
+  --destructive: var(--vscode-errorForeground, oklch(0.577 0.245 27.325));
+  --border: var(--vscode-panel-border, var(--vscode-input-border, oklch(0.92 0.004 286.32)));
+  --input: var(--vscode-input-background, var(--vscode-panel-background, oklch(0.92 0.004 286.32)));
+  --ring: var(--vscode-focusBorder, oklch(0.552 0.016 285.938));
+}
+
+/* VSCode-style flat buttons: no visible border, background changes on hover.
+   The built-in theme keeps its bordered / foreground-shifting behaviour. */
+.vscode-theme [data-slot="button"] {
+  border: none !important;
+  box-shadow: none !important;
+  outline: none !important;
+  background-clip: border-box !important;
+}
+
+.vscode-theme [data-variant="ghost"]:hover,
+.vscode-theme [data-variant="outline"]:hover {
+  color: inherit;
+}
+
+/* Ensure ghost/outline buttons get a visible hover background in VSCode theme.
+   We target by data-variant directly in case data-slot is stripped by Radix Slot. */
+.vscode-theme [data-variant="ghost"]:hover,
+.vscode-theme [data-variant="outline"]:hover {
+  background-color: color-mix(in oklch, var(--foreground) 20%, var(--background));
+}
+
+/* Plan mode button (custom component, not shadcn Button) */
+.vscode-theme [data-plan-mode="inactive"]:hover {
+  background-color: color-mix(in oklch, var(--foreground) 20%, var(--background));
+}
+
+/* Menu items: use a solid hover tint instead of the accent color which often
+   clashes with dark VSCode themes. */
+.vscode-theme [data-slot="dropdown-menu-item"]:hover,
+.vscode-theme [data-slot="command-item"]:hover,
+.vscode-theme [data-slot="context-menu-item"]:hover,
+.vscode-theme [data-session-item]:hover,
+.vscode-theme [data-block-header]:hover {
+  background-color: color-mix(in oklch, var(--foreground) 20%, var(--background));
+}
+
+/* Remove bright borders from common UI elements in VSCode theme mode when
+   using high-contrast themes. We keep .border-border transparent so section
+   separators stay flat, but allow opacity variants and .border-input so
+   specific components (token bar, input area, thinking block, etc.) can show
+   subtle borders. */
+.vscode-theme .border-border {
+  border-color: transparent !important;
+}
+
+.vscode-theme ::-webkit-scrollbar-thumb {
+  background: var(--vscode-scrollbarSlider-background, var(--vscode-descriptionForeground, var(--muted-foreground)));
+  opacity: 0.4;
+}
+
+.vscode-theme ::-webkit-scrollbar-thumb:hover {
+  background: var(--vscode-scrollbarSlider-hoverBackground, var(--vscode-descriptionForeground, var(--muted-foreground)));
+  opacity: 0.6;
 }
 
 ::-webkit-scrollbar {

--- a/node/vscode_extension/webview-ui/src/styles/index.css
+++ b/node/vscode_extension/webview-ui/src/styles/index.css
@@ -186,6 +186,60 @@ body {
   opacity: 0.6;
 }
 
+/* Component overrides for VSCode theme — revert-safe: these classes are
+   no-ops in built-in mode because no rules target them. */
+
+/* Thinking block: flat input background, no border */
+.vscode-theme .thinking-block {
+  background-color: var(--input) !important;
+  border-color: transparent !important;
+}
+
+.vscode-theme .thinking-block .text-zinc-500,
+.vscode-theme .thinking-block .text-zinc-400 {
+  color: var(--muted-foreground);
+}
+
+.vscode-theme .thinking-block .text-zinc-700,
+.vscode-theme .thinking-block .text-zinc-300 {
+  color: var(--foreground);
+}
+
+.vscode-theme .thinking-block [data-block-header]:hover {
+  background-color: color-mix(in oklch, var(--foreground) 20%, var(--background));
+}
+
+.vscode-theme .thinking-block > .border-t {
+  border-color: var(--border);
+}
+
+/* Tool call card: flat input background, no border */
+.vscode-theme .tool-call-card {
+  background-color: var(--input) !important;
+  border-color: transparent !important;
+}
+
+.vscode-theme .tool-call-card > .border-t {
+  border-color: var(--border);
+}
+
+/* Input area: flat input background, no border */
+.vscode-theme .input-area-wrapper {
+  background-color: var(--input) !important;
+  border-color: transparent !important;
+}
+
+/* User message bubbles: muted background */
+.vscode-theme .user-message-bubble,
+.vscode-theme .steer-bubble {
+  background-color: var(--muted) !important;
+}
+
+/* Chat status bar: use theme border */
+.vscode-theme .chat-status-bar {
+  border-color: color-mix(in oklch, var(--border) 40%, transparent) !important;
+}
+
 ::-webkit-scrollbar {
   width: 6px;
   height: 6px;

--- a/node/vscode_extension/webview-ui/src/styles/index.css
+++ b/node/vscode_extension/webview-ui/src/styles/index.css
@@ -239,6 +239,32 @@ body {
   color: var(--vscode-chat-requestForeground, var(--vscode-foreground));
 }
 
+/* Tool code blocks: use VSCode's code-block background colour */
+.vscode-theme .tool-codeblock pre {
+  background-color: var(--vscode-textCodeBlock-background, var(--input)) !important;
+  color: var(--vscode-foreground, var(--foreground)) !important;
+}
+
+.vscode-theme .tool-codeblock .text-zinc-500 {
+  color: var(--muted-foreground);
+}
+
+.vscode-theme .codeblock-expand {
+  background-color: var(--vscode-button-secondaryBackground, var(--popover)) !important;
+  color: var(--vscode-button-secondaryForeground, var(--muted-foreground)) !important;
+  border: 1px solid var(--vscode-panel-border, var(--border)) !important;
+}
+
+.vscode-theme .codeblock-expand:hover {
+  color: var(--vscode-button-secondaryForeground, var(--foreground)) !important;
+}
+
+/* Todo list status icons (done / empty) */
+.vscode-theme [data-todo-status="done"] svg,
+.vscode-theme [data-todo-status="empty"] svg {
+  color: var(--muted-foreground) !important;
+}
+
 ::-webkit-scrollbar {
   width: 6px;
   height: 6px;


### PR DESCRIPTION
## PR Summary

This PR adds a `kimi.themeMode` setting that allows the extension's webview to optionally inherit VSCode's native theme colors instead of the built-in shadcn palette. It fixes a root cause where an unlayered `* { border-color: var(--border); }` rule was overriding all Tailwind border utilities, causing bright borders in high-contrast themes. The fix makes default borders transparent in VSCode mode while preserving explicit colored borders, adds computed `color-mix` hover highlights for buttons and menu items (replacing near-invisible `bg-muted/50`), and updates key components to use theme-mapped backgrounds instead of hardcoded zinc colors.

### Changes

- Added `kimi.themeMode` setting and `.vscode-theme` CSS variable mappings to `--vscode-*` colors
- Fixed unlayered `*` border rule that was stomping Tailwind utilities; default borders are now transparent in VSCode mode
- Added `color-mix(in oklch, var(--foreground) 20%, var(--background))` hover tint to buttons, dropdown items, command items, session items, tool headers, thinking headers, and plan mode button
- Updated token bar → theme border; input area / thinking / tool blocks → `bg-input`; user bubbles → `bg-muted`
- Removed `dark:hover:bg-muted/50` and `dark:hover:bg-input/50` from shadcn button variants for consistent cross-theme hover

Resolves #162 