### PR TITLE
chore(vscode): bump version to 0.5.8 and update bundled CLI to 1.42.0

### DIFF
--- a/node/vscode_extension/package.json
+++ b/node/vscode_extension/package.json
@@ -3,7 +3,7 @@
   "publisher": "moonshot-ai",
   "displayName": "Kimi Code",
   "description": "Official Kimi Code plugin for VS Code",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Changes

- Bump vscode extension version from 0.5.7 to 0.5.8
- Update bundled Kimi CLI from 1.37.0 to 1.42.0

Picked up automatically at package time via `scripts/download-cli.js` (pulls `MoonshotAI/kimi-cli` `releases/latest`).