### PR TITLE
fix(vscode): fail when native CLI asset is missing

### DIFF
--- a/node/vscode_extension/scripts/download-cli.js
+++ b/node/vscode_extension/scripts/download-cli.js
@@ -92,6 +92,9 @@ async function main() {
     console.log("Checksum verified ✓");
 
     fs.writeFileSync(path.join(binDir, `archive.${info.ext}`), data);
+  } else if (info.target) {
+    const filename = `kimi-${manifest.version}-${info.target}.${info.ext}`;
+    throw new Error(`Missing native CLI asset for ${platform}: expected ${filename} and ${filename}.sha256 in ${release.tag_name}`);
   } else {
     console.log(`No native CLI for ${platform}, will use UV fallback at runtime`);
   }


### PR DESCRIPTION
## Summary
- fail VS Code extension packaging when a platform declares a native CLI target but the release asset or checksum is missing
- prevent publishing a VSIX that has only the CLI manifest but no bundled archive for native platforms

## Verification
- node --check node/vscode_extension/scripts/download-cli.js
- pnpm package:platform darwin-x64
- unzip -l kimi-code-darwin-x64.vsix 'extension/bin/kimi/*'
- unzip -p kimi-code-darwin-x64.vsix extension/bin/kimi/manifest.json | jq '.version, .bundledPlatform, .platforms["darwin-x64"].filename'