### PR TITLE
chore(vscode): bump version to 0.5.9

### DIFF
--- a/node/vscode_extension/package.json
+++ b/node/vscode_extension/package.json
@@ -3,7 +3,7 @@
   "publisher": "moonshot-ai",
   "displayName": "Kimi Code",
   "description": "Official Kimi Code plugin for VS Code",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- bump the VS Code extension package version from 0.5.8 to 0.5.9 for the next Marketplace/OpenVSX release

## Verification
- jq -r '.version' node/vscode_extension/package.json