### PR TITLE
Show CLI startup error details

### DIFF
--- a/node/vscode_extension/src/managers/cli.manager.ts
+++ b/node/vscode_extension/src/managers/cli.manager.ts
@@ -24,6 +24,21 @@ const MIN_WIRE_VERSION = "1.1";
 
 let instance: CLIManager;
 
+function errorText(err: unknown): string {
+  const stderr = textFromErrorField(err, "stderr");
+  const stdout = textFromErrorField(err, "stdout");
+  const message = err instanceof Error ? err.message : String(err);
+  return stderr || stdout || message;
+}
+
+function textFromErrorField(err: unknown, field: "stdout" | "stderr"): string {
+  const value = (err as { stdout?: unknown; stderr?: unknown } | null)?.[field];
+  if (!value) {
+    return "";
+  }
+  return Buffer.isBuffer(value) ? value.toString().trim() : String(value).trim();
+}
+
 export const initCLIManager = (ctx: vscode.ExtensionContext) => (instance = new CLIManager(ctx));
 export const getCLIManager = () => {
   if (!instance) {
@@ -77,7 +92,7 @@ export class CLIManager {
       }
     } catch (err) {
       console.error("Error ensuring CLI:", err);
-      return { ok: false, resolved, error: { type: "extract_failed", message: String(err) } };
+      return { ok: false, resolved, error: { type: "extract_failed", message: errorText(err) } };
     }
 
     return this.verify(workDir, resolved);
@@ -144,7 +159,7 @@ export class CLIManager {
       wireVersion = info.wire_protocol_version;
     } catch (err) {
       console.error("Error getting CLI info:", err);
-      return { ok: false, resolved, error: { type: "not_found", message: String(err) } };
+      return { ok: false, resolved, error: { type: "not_found", message: errorText(err) } };
     }
 
     if (compareVersion(cliVersion, MIN_CLI_VERSION) < 0) {
@@ -161,7 +176,7 @@ export class CLIManager {
       return { ok: true, resolved, slashCommands: initResult.slash_commands };
     } catch (err) {
       console.error("Error verifying wire protocol:", err);
-      return { ok: false, resolved, error: { type: "protocol_error", message: String(err) } };
+      return { ok: false, resolved, error: { type: "protocol_error", message: errorText(err) } };
     }
   }
 

--- a/node/vscode_extension/webview-ui/src/components/ConfigErrorScreen.tsx
+++ b/node/vscode_extension/webview-ui/src/components/ConfigErrorScreen.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { IconAlertTriangle, IconTerminal2, IconLoader2, IconFolderOpen, IconSettings, IconExternalLink, IconChevronRight, IconArrowLeft, IconRefresh } from "@tabler/icons-react";
+import { IconAlertTriangle, IconTerminal2, IconLoader2, IconFolderOpen, IconSettings, IconExternalLink, IconChevronRight, IconArrowLeft, IconRefresh, IconCopy, IconCheck } from "@tabler/icons-react";
 import { Button } from "@/components/ui/button";
 import { KimiMascot } from "./KimiMascot";
 import { bridge } from "@/services";
@@ -54,11 +54,42 @@ function ManualSetupHint() {
   );
 }
 
-function CLIErrorContent({ cliResult }: { cliResult?: CLICheckResult | null }) {
+function CLIErrorDetails({ message }: { message?: string }) {
+  const [copied, setCopied] = useState(false);
+
+  if (!message) {
+    return null;
+  }
+
+  const copyError = async () => {
+    await navigator.clipboard.writeText(message);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="bg-muted/50 rounded-lg p-4 text-left space-y-2">
+      <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+        <div className="flex items-center gap-2 min-w-0">
+          <IconTerminal2 className="size-4" />
+          <span>CLI error output:</span>
+        </div>
+        <Button onClick={copyError} variant="ghost" size="xs" className="h-6 px-1.5 gap-1 shrink-0">
+          {copied ? <IconCheck className="size-3" /> : <IconCopy className="size-3" />}
+          {copied ? "Copied" : "Copy to Ask AI"}
+        </Button>
+      </div>
+      <pre className="max-h-36 overflow-auto whitespace-pre-wrap break-words text-xs bg-background rounded px-3 py-2 font-mono text-foreground">{message}</pre>
+    </div>
+  );
+}
+
+function CLIErrorContent({ cliResult, errorMessage: fallbackErrorMessage }: { cliResult?: CLICheckResult | null; errorMessage?: string | null }) {
   const isCustomPath = cliResult?.resolved?.isCustomPath ?? false;
   const errorType = cliResult?.error?.type ?? "not_found";
   const title = CLI_ERROR_TITLES[errorType];
   const path = cliResult?.resolved?.path;
+  const errorMessage = cliResult?.error?.message ?? fallbackErrorMessage ?? undefined;
 
   if (isCustomPath) {
     return (
@@ -82,6 +113,8 @@ function CLIErrorContent({ cliResult }: { cliResult?: CLICheckResult | null }) {
           </p>
         </div>
 
+        <CLIErrorDetails message={errorMessage} />
+
         <div className="bg-muted/50 rounded-lg p-4 text-left space-y-3">
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <IconTerminal2 className="size-4" />
@@ -104,6 +137,8 @@ function CLIErrorContent({ cliResult }: { cliResult?: CLICheckResult | null }) {
           {errorType === "extract_failed" ? "Failed to extract the bundled CLI. Please install manually." : "The bundled CLI is unavailable. Please install manually."}
         </p>
       </div>
+
+      <CLIErrorDetails message={errorMessage} />
 
       <div className="bg-muted/50 rounded-lg p-4 text-left space-y-3">
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
@@ -176,7 +211,7 @@ function NoModelsContent({ onRefresh, onBackToLogin }: { onRefresh?: () => void;
   );
 }
 
-export function ConfigErrorScreen({ type, cliResult, onRefresh, onBackToLogin }: Props) {
+export function ConfigErrorScreen({ type, cliResult, errorMessage, onRefresh, onBackToLogin }: Props) {
   if (type === "loading") {
     return (
       <div className="h-full flex items-center justify-center p-6">
@@ -217,10 +252,10 @@ export function ConfigErrorScreen({ type, cliResult, onRefresh, onBackToLogin }:
 
   if (type === "cli-error") {
     return (
-      <div className="h-full flex items-center justify-center p-6">
-        <div className="max-w-sm text-center space-y-6">
+      <div className="flex-1 min-h-0 overflow-y-auto p-6">
+        <div className="max-w-sm mx-auto text-center space-y-6">
           <KimiMascot className="h-10 mx-auto opacity-50" />
-          <CLIErrorContent cliResult={cliResult} />
+          <CLIErrorContent cliResult={cliResult} errorMessage={errorMessage} />
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- surface stderr/stdout from bundled CLI startup failures in the VS Code error screen
- add a Copy to Ask AI action for the displayed CLI error output
- keep the copy payload focused on the raw CLI error output

## Verification
- pnpm --filter kimi-code build
- ./node_modules/.bin/vsce package --target win32-x64 --out kimi-code-win32-x64-0.5.10-pr188.vsix