### PR TITLE
chore(vscode): add platform release workflow

### DIFF
--- a/.github/workflows/vscode.yml
+++ b/.github/workflows/vscode.yml
@@ -1,32 +1,50 @@
-name: VSCode Extension CI/CD
+name: VSCode Extension Platform Package
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [main, master]
     paths:
-      - 'node/**'
-      - '.github/workflows/vscode.yml'
+      - "node/**"
+      - ".github/workflows/vscode.yml"
   pull_request:
-    branches: [ main, master ]
+    branches: [main, master]
     paths:
-      - 'node/**'
-      - '.github/workflows/vscode.yml'
+      - "node/**"
+      - ".github/workflows/vscode.yml"
   workflow_dispatch:
     inputs:
+      extension_version:
+        description: "Expected VS Code extension version, for example 0.5.9"
+        required: true
+        type: string
+      cli_version:
+        description: "Expected Kimi CLI version to bundle, for example 1.43.0"
+        required: true
+        type: string
+      run_windows_smoke:
+        description: "Run win32-x64 bundled CLI smoke"
+        required: true
+        type: boolean
+        default: true
       publish_to_marketplace:
-        description: 'Publish to VSCode Marketplace'
+        description: "Publish verified VSIX files to VS Code Marketplace"
         required: true
         type: boolean
         default: false
       publish_to_open_vsx:
-        description: 'Publish to Open VSX Registry'
+        description: "Publish verified VSIX files to Open VSX"
         required: true
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    name: Build extension
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'workflow_dispatch' }}
 
     steps:
       - name: Checkout code
@@ -41,7 +59,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
+          cache: "pnpm"
           cache-dependency-path: node/pnpm-lock.yaml
 
       - name: Install dependencies
@@ -52,21 +70,14 @@ jobs:
         run: pnpm build
         working-directory: node/vscode_extension
 
-      - name: Package
-        run: pnpm run package:no-embedded
-        working-directory: node/vscode_extension
-
-      - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: vscode-extension
-          path: node/vscode_extension/*.vsix
-          retention-days: 30
-
-  publish:
+  package:
+    name: Package platform VSIX
     runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'workflow_dispatch' && (inputs.publish_to_marketplace || inputs.publish_to_open_vsx)
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    outputs:
+      extension_version: ${{ steps.meta.outputs.extension_version }}
+      expected_cli_version: ${{ steps.meta.outputs.expected_cli_version }}
+      artifact_name: ${{ steps.meta.outputs.artifact_name }}
 
     steps:
       - name: Checkout code
@@ -81,31 +92,304 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
+          cache: "pnpm"
           cache-dependency-path: node/pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install
         working-directory: node/vscode_extension
 
+      - name: Read release metadata
+        id: meta
+        shell: bash
+        working-directory: node/vscode_extension
+        env:
+          EXPECTED_EXTENSION_VERSION: ${{ inputs.extension_version }}
+          EXPECTED_CLI_VERSION: ${{ inputs.cli_version }}
+        run: |
+          set -euo pipefail
+
+          expected_extension_version="${EXPECTED_EXTENSION_VERSION#v}"
+          expected_cli_version="${EXPECTED_CLI_VERSION#v}"
+          if [[ -z "$expected_extension_version" ]]; then
+            echo "extension_version input is required" >&2
+            exit 1
+          fi
+          if [[ -z "$expected_cli_version" ]]; then
+            echo "cli_version input is required" >&2
+            exit 1
+          fi
+
+          extension_version="$(node -p "require('./package.json').version")"
+          if [[ "$extension_version" != "$expected_extension_version" ]]; then
+            echo "Extension version mismatch: package.json has ${extension_version}, expected ${expected_extension_version}" >&2
+            exit 1
+          fi
+
+          artifact_name="kimi-code-vsix-${extension_version}-cli-${expected_cli_version}"
+
+          echo "extension_version=${extension_version}" >> "$GITHUB_OUTPUT"
+          echo "expected_cli_version=${expected_cli_version}" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=${artifact_name}" >> "$GITHUB_OUTPUT"
+
+          echo "Extension version: ${extension_version}"
+          echo "Expected CLI version: ${expected_cli_version}"
+
+      - name: Package 6 platform VSIX files
+        run: |
+          rm -f *.vsix
+          pnpm package:platform
+        working-directory: node/vscode_extension
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Verify platform packages
+        shell: bash
+        working-directory: node/vscode_extension
+        env:
+          EXPECTED_CLI_VERSION: ${{ steps.meta.outputs.expected_cli_version }}
+        run: |
+          set -euo pipefail
+
+          targets=(
+            darwin-arm64
+            darwin-x64
+            linux-arm64
+            linux-x64
+            win32-arm64
+            win32-x64
+          )
+
+          actual_count="$(find . -maxdepth 1 -name 'kimi-code-*.vsix' | wc -l | tr -d ' ')"
+          if [[ "$actual_count" != "${#targets[@]}" ]]; then
+            echo "Expected ${#targets[@]} VSIX files, got ${actual_count}" >&2
+            find . -maxdepth 1 -name 'kimi-code-*.vsix' -print >&2
+            exit 1
+          fi
+
+          for target in "${targets[@]}"; do
+            file="kimi-code-${target}.vsix"
+            manifest="/tmp/kimi-code-${target}.manifest.json"
+
+            if [[ ! -f "$file" ]]; then
+              echo "Missing package: ${file}" >&2
+              exit 1
+            fi
+
+            if [[ "$target" == win32-* ]]; then
+              archive="extension/bin/kimi/archive.zip"
+            else
+              archive="extension/bin/kimi/archive.tar.gz"
+            fi
+
+            unzip -p "$file" extension/bin/kimi/manifest.json > "$manifest"
+            unzip -l "$file" "$archive" >/dev/null
+
+            python3 - "$target" "$EXPECTED_CLI_VERSION" "$manifest" <<'PY'
+          import json
+          import sys
+
+          target, expected_version, manifest_path = sys.argv[1:4]
+          with open(manifest_path, encoding="utf-8") as f:
+              manifest = json.load(f)
+
+          version = manifest.get("version")
+          tag = str(manifest.get("tag", ""))
+          bundled_platform = manifest.get("bundledPlatform")
+          platforms = manifest.get("platforms") or {}
+          asset = platforms.get(target)
+
+          failures = []
+          if version != expected_version:
+              failures.append(f"version={version!r}, expected {expected_version!r}")
+          if tag.removeprefix("v") != expected_version:
+              failures.append(f"tag={tag!r}, expected {expected_version!r} or v{expected_version}")
+          if bundled_platform != target:
+              failures.append(f"bundledPlatform={bundled_platform!r}, expected {target!r}")
+          if not asset:
+              failures.append(f"platforms[{target!r}] is missing")
+          elif target.startswith("win32-") and not asset.get("filename", "").endswith(".zip"):
+              failures.append(f"windows asset should be .zip, got {asset.get('filename')!r}")
+          elif not target.startswith("win32-") and not asset.get("filename", "").endswith(".tar.gz"):
+              failures.append(f"non-windows asset should be .tar.gz, got {asset.get('filename')!r}")
+
+          if failures:
+              raise SystemExit(f"{target} manifest check failed: " + "; ".join(failures))
+
+          print(f"{target}: CLI {version}, tag {tag}, archive manifest OK")
+          PY
+          done
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.meta.outputs.artifact_name }}
+          path: node/vscode_extension/kimi-code-*.vsix
+          retention-days: 14
+
+  smoke-windows:
+    name: Smoke win32-x64 bundled CLI
+    runs-on: windows-latest
+    needs: package
+    if: ${{ github.event_name == 'workflow_dispatch' && (inputs.run_windows_smoke || inputs.publish_to_marketplace || inputs.publish_to_open_vsx) }}
+
+    steps:
       - name: Download VSIX artifact
         uses: actions/download-artifact@v4
         with:
-          name: vscode-extension
-          path: node/vscode_extension/
+          name: ${{ needs.package.outputs.artifact_name }}
+          path: node/vscode_extension
 
-      - name: Publish to VSCode Marketplace
-        if: inputs.publish_to_marketplace
+      - name: Run kimi.exe info smoke
+        shell: pwsh
+        working-directory: node/vscode_extension
+        env:
+          EXPECTED_CLI_VERSION: ${{ needs.package.outputs.expected_cli_version }}
         run: |
-          npx vsce publish --no-dependencies
+          $ErrorActionPreference = "Stop"
+
+          $vsix = Resolve-Path ".\kimi-code-win32-x64.vsix"
+          $workDir = Join-Path $env:RUNNER_TEMP "kimi-vscode-smoke"
+          $vsixDir = Join-Path $workDir "vsix"
+          $cliDir = Join-Path $workDir "cli"
+
+          Remove-Item $workDir -Recurse -Force -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $vsixDir, $cliDir | Out-Null
+
+          $vsixZip = Join-Path $workDir "kimi-code-win32-x64.zip"
+          Copy-Item $vsix $vsixZip
+          Expand-Archive -Path $vsixZip -DestinationPath $vsixDir -Force
+
+          $archive = Join-Path $vsixDir "extension\bin\kimi\archive.zip"
+          if (!(Test-Path $archive)) {
+            throw "Missing bundled CLI archive: $archive"
+          }
+
+          Expand-Archive -Path $archive -DestinationPath $cliDir -Force
+          $kimi = Get-ChildItem -Path $cliDir -Recurse -Filter "kimi.exe" | Select-Object -First 1
+          if (!$kimi) {
+            throw "kimi.exe not found after extracting $archive"
+          }
+
+          $output = & $kimi.FullName info --json
+          if ($LASTEXITCODE -ne 0) {
+            throw "kimi.exe info --json failed with exit code $LASTEXITCODE"
+          }
+
+          $json = ($output | Out-String).Trim()
+          $info = $json | ConvertFrom-Json
+          if ($info.kimi_cli_version -ne $env:EXPECTED_CLI_VERSION) {
+            throw "CLI version mismatch: got $($info.kimi_cli_version), expected $env:EXPECTED_CLI_VERSION"
+          }
+          if (!$info.wire_protocol_version) {
+            throw "wire_protocol_version is missing from kimi.exe info --json"
+          }
+
+          Write-Host "kimi.exe info OK: version=$($info.kimi_cli_version), wire=$($info.wire_protocol_version)"
+
+  publish:
+    name: Publish platform VSIX
+    runs-on: ubuntu-latest
+    needs: [package, smoke-windows]
+    if: ${{ github.event_name == 'workflow_dispatch' && needs.package.result == 'success' && needs.smoke-windows.result == 'success' && (inputs.publish_to_marketplace || inputs.publish_to_open_vsx) }}
+    environment: release
+
+    steps:
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.package.outputs.artifact_name }}
+          path: node/vscode_extension
+
+      - name: Check publish tokens
+        shell: bash
+        env:
+          VSCE_PAT: ${{ secrets.VSCODE_MARKETPLACE_PAT }}
+          OVSX_PAT: ${{ secrets.OPEN_VSX_TOKEN }}
+          PUBLISH_TO_MARKETPLACE: ${{ inputs.publish_to_marketplace }}
+          PUBLISH_TO_OPEN_VSX: ${{ inputs.publish_to_open_vsx }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$PUBLISH_TO_MARKETPLACE" == "true" && -z "$VSCE_PAT" ]]; then
+            echo "VSCODE_MARKETPLACE_PAT secret is required to publish to VS Code Marketplace" >&2
+            exit 1
+          fi
+
+          if [[ "$PUBLISH_TO_OPEN_VSX" == "true" && -z "$OVSX_PAT" ]]; then
+            echo "OPEN_VSX_TOKEN secret is required to publish to Open VSX" >&2
+            exit 1
+          fi
+
+      - name: Publish to VS Code Marketplace
+        if: ${{ inputs.publish_to_marketplace }}
+        shell: bash
         working-directory: node/vscode_extension
         env:
           VSCE_PAT: ${{ secrets.VSCODE_MARKETPLACE_PAT }}
-
-      - name: Publish to Open VSX Registry
-        if: inputs.publish_to_open_vsx
         run: |
-          npx ovsx publish
+          set -euo pipefail
+
+          publish_vsce() {
+            local file="$1"
+            local output
+            local status
+
+            set +e
+            output="$(npx -y @vscode/vsce publish --packagePath "$file" 2>&1)"
+            status=$?
+            set -e
+
+            printf '%s\n' "$output"
+            if [[ "$status" -ne 0 ]]; then
+              if grep -qi "already exists" <<<"$output"; then
+                echo "Already published: $file"
+                return 0
+              fi
+              return "$status"
+            fi
+          }
+
+          for file in kimi-code-*.vsix; do
+            echo "Publishing $file to VS Code Marketplace"
+            publish_vsce "$file"
+          done
+
+      - name: Publish to Open VSX
+        if: ${{ inputs.publish_to_open_vsx }}
+        shell: bash
         working-directory: node/vscode_extension
         env:
           OVSX_PAT: ${{ secrets.OPEN_VSX_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          publish_ovsx() {
+            local file="$1"
+            local output
+            local status
+
+            set +e
+            output="$(npx -y ovsx publish "$file" 2>&1)"
+            status=$?
+            set -e
+
+            printf '%s\n' "$output"
+            if [[ "$status" -ne 0 ]]; then
+              if grep -qi "already exists" <<<"$output"; then
+                echo "Already published: $file"
+                return 0
+              fi
+              return "$status"
+            fi
+          }
+
+          for file in kimi-code-*.vsix; do
+            echo "Publishing $file to Open VSX"
+            publish_ovsx "$file"
+          done

--- a/.github/workflows/vscode.yml
+++ b/.github/workflows/vscode.yml
@@ -340,7 +340,21 @@ jobs:
             fi
           }
 
-          for file in kimi-code-*.vsix; do
+          vsix_files=(
+            kimi-code-darwin-arm64.vsix
+            kimi-code-darwin-x64.vsix
+            kimi-code-linux-arm64.vsix
+            kimi-code-linux-x64.vsix
+            kimi-code-win32-arm64.vsix
+            kimi-code-win32-x64.vsix
+          )
+
+          for file in "${vsix_files[@]}"; do
+            if [[ ! -f "$file" ]]; then
+              echo "Missing expected .vsix file: $file" >&2
+              exit 1
+            fi
+
             echo "Publishing $file to VS Code Marketplace"
             publish_vsce "$file"
           done
@@ -374,7 +388,21 @@ jobs:
             fi
           }
 
-          for file in kimi-code-*.vsix; do
+          vsix_files=(
+            kimi-code-darwin-arm64.vsix
+            kimi-code-darwin-x64.vsix
+            kimi-code-linux-arm64.vsix
+            kimi-code-linux-x64.vsix
+            kimi-code-win32-arm64.vsix
+            kimi-code-win32-x64.vsix
+          )
+
+          for file in "${vsix_files[@]}"; do
+            if [[ ! -f "$file" ]]; then
+              echo "Missing expected .vsix file: $file" >&2
+              exit 1
+            fi
+
             echo "Publishing $file to Open VSX"
             publish_ovsx "$file"
           done

--- a/.github/workflows/vscode.yml
+++ b/.github/workflows/vscode.yml
@@ -13,14 +13,6 @@ on:
       - ".github/workflows/vscode.yml"
   workflow_dispatch:
     inputs:
-      extension_version:
-        description: "Expected VS Code extension version, for example 0.5.9"
-        required: true
-        type: string
-      cli_version:
-        description: "Expected Kimi CLI version to bundle, for example 1.43.0"
-        required: true
-        type: string
       run_windows_smoke:
         description: "Run win32-x64 bundled CLI smoke"
         required: true
@@ -76,8 +68,8 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' }}
     outputs:
       extension_version: ${{ steps.meta.outputs.extension_version }}
-      expected_cli_version: ${{ steps.meta.outputs.expected_cli_version }}
-      artifact_name: ${{ steps.meta.outputs.artifact_name }}
+      expected_cli_version: ${{ steps.verify.outputs.expected_cli_version }}
+      artifact_name: ${{ steps.verify.outputs.artifact_name }}
 
     steps:
       - name: Checkout code
@@ -103,37 +95,13 @@ jobs:
         id: meta
         shell: bash
         working-directory: node/vscode_extension
-        env:
-          EXPECTED_EXTENSION_VERSION: ${{ inputs.extension_version }}
-          EXPECTED_CLI_VERSION: ${{ inputs.cli_version }}
         run: |
           set -euo pipefail
 
-          expected_extension_version="${EXPECTED_EXTENSION_VERSION#v}"
-          expected_cli_version="${EXPECTED_CLI_VERSION#v}"
-          if [[ -z "$expected_extension_version" ]]; then
-            echo "extension_version input is required" >&2
-            exit 1
-          fi
-          if [[ -z "$expected_cli_version" ]]; then
-            echo "cli_version input is required" >&2
-            exit 1
-          fi
-
           extension_version="$(node -p "require('./package.json').version")"
-          if [[ "$extension_version" != "$expected_extension_version" ]]; then
-            echo "Extension version mismatch: package.json has ${extension_version}, expected ${expected_extension_version}" >&2
-            exit 1
-          fi
-
-          artifact_name="kimi-code-vsix-${extension_version}-cli-${expected_cli_version}"
 
           echo "extension_version=${extension_version}" >> "$GITHUB_OUTPUT"
-          echo "expected_cli_version=${expected_cli_version}" >> "$GITHUB_OUTPUT"
-          echo "artifact_name=${artifact_name}" >> "$GITHUB_OUTPUT"
-
           echo "Extension version: ${extension_version}"
-          echo "Expected CLI version: ${expected_cli_version}"
 
       - name: Package 6 platform VSIX files
         run: |
@@ -144,10 +112,11 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Verify platform packages
+        id: verify
         shell: bash
         working-directory: node/vscode_extension
         env:
-          EXPECTED_CLI_VERSION: ${{ steps.meta.outputs.expected_cli_version }}
+          EXTENSION_VERSION: ${{ steps.meta.outputs.extension_version }}
         run: |
           set -euo pipefail
 
@@ -159,6 +128,7 @@ jobs:
             win32-arm64
             win32-x64
           )
+          expected_cli_version=""
 
           actual_count="$(find . -maxdepth 1 -name 'kimi-code-*.vsix' | wc -l | tr -d ' ')"
           if [[ "$actual_count" != "${#targets[@]}" ]]; then
@@ -185,11 +155,11 @@ jobs:
             unzip -p "$file" extension/bin/kimi/manifest.json > "$manifest"
             unzip -l "$file" "$archive" >/dev/null
 
-            python3 - "$target" "$EXPECTED_CLI_VERSION" "$manifest" <<'PY'
+            cli_version="$(python3 - "$target" "$manifest" <<'PY'
           import json
           import sys
 
-          target, expected_version, manifest_path = sys.argv[1:4]
+          target, manifest_path = sys.argv[1:3]
           with open(manifest_path, encoding="utf-8") as f:
               manifest = json.load(f)
 
@@ -200,10 +170,10 @@ jobs:
           asset = platforms.get(target)
 
           failures = []
-          if version != expected_version:
-              failures.append(f"version={version!r}, expected {expected_version!r}")
-          if tag.removeprefix("v") != expected_version:
-              failures.append(f"tag={tag!r}, expected {expected_version!r} or v{expected_version}")
+          if not version:
+              failures.append("version is missing")
+          if version and tag.removeprefix("v") != version:
+              failures.append(f"tag={tag!r}, expected {version!r} or v{version}")
           if bundled_platform != target:
               failures.append(f"bundledPlatform={bundled_platform!r}, expected {target!r}")
           if not asset:
@@ -216,14 +186,29 @@ jobs:
           if failures:
               raise SystemExit(f"{target} manifest check failed: " + "; ".join(failures))
 
-          print(f"{target}: CLI {version}, tag {tag}, archive manifest OK")
+          print(version)
           PY
+            )"
+
+            if [[ -z "$expected_cli_version" ]]; then
+              expected_cli_version="$cli_version"
+            elif [[ "$cli_version" != "$expected_cli_version" ]]; then
+              echo "CLI version mismatch: ${target} has ${cli_version}, expected ${expected_cli_version}" >&2
+              exit 1
+            fi
+
+            echo "${target}: CLI ${cli_version}, archive manifest OK"
           done
+
+          artifact_name="kimi-code-vsix-${EXTENSION_VERSION}-cli-${expected_cli_version}"
+          echo "expected_cli_version=${expected_cli_version}" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=${artifact_name}" >> "$GITHUB_OUTPUT"
+          echo "Bundled CLI version: ${expected_cli_version}"
 
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.meta.outputs.artifact_name }}
+          name: ${{ steps.verify.outputs.artifact_name }}
           path: node/vscode_extension/kimi-code-*.vsix
           retention-days: 14
 

--- a/node/vscode_extension/package.json
+++ b/node/vscode_extension/package.json
@@ -252,7 +252,6 @@
     "build:extension": "tsc --noEmit && node esbuild.js --production",
     "download:cli": "node scripts/download-cli.js",
     "package:platform": "node scripts/vsix-package.js",
-    "package:no-embedded": "vsce package --no-dependencies --out kimi-code.vsix",
     "publish:vsix": "node scripts/vsix-publish.js",
     "publish:ovsx": "node scripts/ovsx-publish.js"
   },

--- a/node/vscode_extension/scripts/ovsx-publish.js
+++ b/node/vscode_extension/scripts/ovsx-publish.js
@@ -1,9 +1,17 @@
 #!/usr/bin/env node
-const { execFileSync } = require("child_process");
+const { spawnSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 
 const rootDir = path.join(__dirname, "..");
+const VSIX_FILES = [
+  "kimi-code-darwin-arm64.vsix",
+  "kimi-code-darwin-x64.vsix",
+  "kimi-code-linux-arm64.vsix",
+  "kimi-code-linux-x64.vsix",
+  "kimi-code-win32-arm64.vsix",
+  "kimi-code-win32-x64.vsix",
+];
 
 if (!process.env.OVSX_PAT) {
   console.error("Error: OVSX_PAT environment variable not set");
@@ -11,33 +19,51 @@ if (!process.env.OVSX_PAT) {
   process.exit(1);
 }
 
-const vsixFiles = fs
-  .readdirSync(rootDir)
-  .filter((f) => f.endsWith(".vsix"))
-  .sort();
-
-if (vsixFiles.length === 0) {
-  console.error("No .vsix files found in", rootDir);
-  console.error("Run `pnpm run package:platform all` first.");
+const missing = VSIX_FILES.filter((f) => !fs.existsSync(path.join(rootDir, f)));
+if (missing.length > 0) {
+  console.error("Missing expected .vsix file(s):");
+  missing.forEach((f) => console.error(`  - ${f}`));
+  console.error("Run `pnpm run package:platform` first.");
   process.exit(1);
 }
 
-console.log(`Found ${vsixFiles.length} vsix file(s) to publish to OpenVSX:\n`);
-vsixFiles.forEach((f) => console.log(`  - ${f}`));
+console.log(`Found ${VSIX_FILES.length} vsix file(s) to publish to OpenVSX:\n`);
+VSIX_FILES.forEach((f) => console.log(`  - ${f}`));
 console.log();
 
-for (const file of vsixFiles) {
+let failed = false;
+
+for (const file of VSIX_FILES) {
   const filePath = path.join(rootDir, file);
   console.log(`\n========== Publishing ${file} to OpenVSX ==========\n`);
-  try {
-    execFileSync("npx", ["-y", "ovsx", "publish", filePath, "-p", process.env.OVSX_PAT], {
-      cwd: rootDir,
-      stdio: "inherit",
-    });
-    console.log(`✓ Published: ${file}\n`);
-  } catch (err) {
-    console.error(`✗ Failed to publish: ${file}, error:`, err);
+
+  const result = spawnSync("npx", ["-y", "ovsx", "publish", filePath], {
+    cwd: rootDir,
+    encoding: "utf8",
+    env: process.env,
+  });
+
+  const output = `${result.stdout || ""}${result.stderr || ""}`;
+  if (output) {
+    process.stdout.write(output);
   }
+
+  if (result.status !== 0) {
+    if (/already exists/i.test(output)) {
+      console.log(`Already published: ${file}`);
+      continue;
+    }
+
+    console.error(`✗ Failed to publish: ${file}`);
+    failed = true;
+    continue;
+  }
+
+  console.log(`✓ Published: ${file}\n`);
+}
+
+if (failed) {
+  process.exit(1);
 }
 
 console.log("\nAll done!");

--- a/node/vscode_extension/scripts/vsix-package.js
+++ b/node/vscode_extension/scripts/vsix-package.js
@@ -1,4 +1,4 @@
-const { execSync } = require("child_process");
+const { execFileSync } = require("child_process");
 const { rmSync, existsSync } = require("fs");
 const { join } = require("path");
 
@@ -23,13 +23,13 @@ for (const target of targets) {
     }
 
     // 2. Download CLI binary for specific target
-    execSync(`node scripts/download-cli.js ${target}`, {
+    execFileSync("node", ["scripts/download-cli.js", target], {
       cwd: rootDir,
       stdio: "inherit",
     });
 
     // 3. Package extension
-    execSync(`npx vsce package --target ${target} --out kimi-code-${target}.vsix`, {
+    execFileSync("npx", ["-y", "@vscode/vsce", "package", "--no-dependencies", "--target", target, "--out", `kimi-code-${target}.vsix`], {
       cwd: rootDir,
       stdio: "inherit",
     });

--- a/node/vscode_extension/scripts/vsix-publish.js
+++ b/node/vscode_extension/scripts/vsix-publish.js
@@ -1,9 +1,17 @@
 #!/usr/bin/env node
-const { execFileSync } = require("child_process");
+const { spawnSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 
 const rootDir = path.join(__dirname, "..");
+const VSIX_FILES = [
+  "kimi-code-darwin-arm64.vsix",
+  "kimi-code-darwin-x64.vsix",
+  "kimi-code-linux-arm64.vsix",
+  "kimi-code-linux-x64.vsix",
+  "kimi-code-win32-arm64.vsix",
+  "kimi-code-win32-x64.vsix",
+];
 
 if (!process.env.VSCE_PAT) {
   console.error("Error: VSCE_PAT environment variable not set");
@@ -11,33 +19,51 @@ if (!process.env.VSCE_PAT) {
   process.exit(1);
 }
 
-const vsixFiles = fs
-  .readdirSync(rootDir)
-  .filter((f) => f.endsWith(".vsix"))
-  .sort();
-
-if (vsixFiles.length === 0) {
-  console.error("No .vsix files found in", rootDir);
-  console.error("Run `pnpm run package:platform all` first.");
+const missing = VSIX_FILES.filter((f) => !fs.existsSync(path.join(rootDir, f)));
+if (missing.length > 0) {
+  console.error("Missing expected .vsix file(s):");
+  missing.forEach((f) => console.error(`  - ${f}`));
+  console.error("Run `pnpm run package:platform` first.");
   process.exit(1);
 }
 
-console.log(`Found ${vsixFiles.length} vsix file(s) to publish:\n`);
-vsixFiles.forEach((f) => console.log(`  - ${f}`));
+console.log(`Found ${VSIX_FILES.length} vsix file(s) to publish:\n`);
+VSIX_FILES.forEach((f) => console.log(`  - ${f}`));
 console.log();
 
-for (const file of vsixFiles) {
+let failed = false;
+
+for (const file of VSIX_FILES) {
   const filePath = path.join(rootDir, file);
   console.log(`\n========== Publishing ${file} ==========\n`);
-  try {
-    execFileSync("npx", ["-y", "vsce", "publish", "--packagePath", filePath, "-p", process.env.VSCE_PAT], {
-      cwd: rootDir,
-      stdio: "inherit",
-    });
-    console.log(`✓ Published: ${file}\n`);
-  } catch (err) {
-    console.error(`✗ Failed to publish: ${file}, error:`, err);
+
+  const result = spawnSync("npx", ["-y", "@vscode/vsce", "publish", "--packagePath", filePath], {
+    cwd: rootDir,
+    encoding: "utf8",
+    env: process.env,
+  });
+
+  const output = `${result.stdout || ""}${result.stderr || ""}`;
+  if (output) {
+    process.stdout.write(output);
   }
+
+  if (result.status !== 0) {
+    if (/already exists/i.test(output)) {
+      console.log(`Already published: ${file}`);
+      continue;
+    }
+
+    console.error(`✗ Failed to publish: ${file}`);
+    failed = true;
+    continue;
+  }
+
+  console.log(`✓ Published: ${file}\n`);
+}
+
+if (failed) {
+  process.exit(1);
 }
 
 console.log("\nAll done!");


### PR DESCRIPTION
## Summary
- replace the VS Code extension workflow with a platform VSIX release flow
- package and verify the six native CLI VSIX artifacts, then run a win32-x64 bundled CLI smoke check
- add optional Marketplace/Open VSX publish jobs that publish the verified artifacts only
- align local package/publish scripts with CI and remove the legacy no-embedded package script

## Safety
- publish is manual-only via workflow_dispatch
- publish waits for package verification and Windows smoke success
- publish uses the release environment before reading publish secrets
- tokens are read from VSCE_PAT / OVSX_PAT environment variables and are not passed as command arguments
- both CI and local publish paths only publish the six expected platform VSIX files
- already exists is treated as already published; other failures return non-zero

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/vscode.yml"); puts "yaml ok"'
- node --check node/vscode_extension/scripts/vsix-package.js && node --check node/vscode_extension/scripts/vsix-publish.js && node --check node/vscode_extension/scripts/ovsx-publish.js
- node scripts/vsix-package.js darwin-arm64
- fork workflow_dispatch package + Windows smoke: https://github.com/wbxl2000/kimi-agent-sdk/actions/runs/25805160496