### PR TITLE
chore(vscode): bump version to 0.5.10

### DIFF
--- a/node/vscode_extension/package.json
+++ b/node/vscode_extension/package.json
@@ -3,7 +3,7 @@
   "publisher": "moonshot-ai",
   "displayName": "Kimi Code",
   "description": "Official Kimi Code plugin for VS Code",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- bump Kimi Code VS Code extension version to 0.5.10

## Verification
- checked diff only changes node/vscode_extension/package.json version