### PR TITLE
fix(vscode): Fix slow responses in VS Code extension

### DIFF
--- a/node/agent_sdk/protocol.ts
+++ b/node/agent_sdk/protocol.ts
@@ -80,13 +80,53 @@ export interface ReplayStream {
   result: Promise<ReplayResult>;
 }
 
+// Simple linked-list node for O(1) enqueue/dequeue.
+class _QueueNode<T> {
+  value: T;
+  next: _QueueNode<T> | null = null;
+  constructor(value: T) {
+    this.value = value;
+  }
+}
+
+// O(1) enqueue / dequeue queue to avoid the O(n) cost of Array.prototype.shift().
+class _EventQueue<T> {
+  private head: _QueueNode<T> | null = null;
+  private tail: _QueueNode<T> | null = null;
+  private _size = 0;
+
+  get size(): number {
+    return this._size;
+  }
+
+  enqueue(value: T): void {
+    const node = new _QueueNode(value);
+    if (this.tail) {
+      this.tail.next = node;
+    } else {
+      this.head = node;
+    }
+    this.tail = node;
+    this._size++;
+  }
+
+  dequeue(): T | undefined {
+    if (!this.head) return undefined;
+    const value = this.head.value;
+    this.head = this.head.next;
+    if (!this.head) this.tail = null;
+    this._size--;
+    return value;
+  }
+}
+
 // Event Channel Helper
 export function createEventChannel<T>(): {
   iterable: AsyncIterable<T>;
   push: (value: T) => void;
   finish: () => void;
 } {
-  const queue: T[] = [];
+  const queue = new _EventQueue<T>();
   const resolvers: Array<(result: IteratorResult<T>) => void> = [];
   let finished = false;
 
@@ -94,7 +134,7 @@ export function createEventChannel<T>(): {
     iterable: {
       [Symbol.asyncIterator]: () => ({
         next: () => {
-          const queued = queue.shift();
+          const queued = queue.dequeue();
           if (queued !== undefined) {
             return Promise.resolve({ done: false as const, value: queued });
           }
@@ -113,7 +153,7 @@ export function createEventChannel<T>(): {
       if (resolver) {
         resolver({ done: false, value });
       } else {
-        queue.push(value);
+        queue.enqueue(value);
       }
     },
     finish: () => {

--- a/node/vscode_extension/src/handlers/chat.handler.ts
+++ b/node/vscode_extension/src/handlers/chat.handler.ts
@@ -179,8 +179,16 @@ const streamChat: Handler<StreamChatParams, { done: boolean }> = async (params, 
     ctx.setTurn(turn);
 
     let result: RunResult = { status: "finished" };
+    let eventCount = 0;
 
     for await (const event of turn) {
+      // Yield to the event loop every 100 events so that I/O (e.g.
+      // readline consuming stdout from the CLI) does not starve when
+      // the createEventChannel queue is large.
+      if (++eventCount % 100 === 0) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
+
       const eventAny = event as any;
       const eventType = event.type;
       const payload = eventAny.payload;


### PR DESCRIPTION
Replace array queue with O(1) linked list, yield every 100 events

- Avoid Array.prototype.shift() bottleneck in createEventChannel
- Prevent I/O starvation in chat handler by yielding to the event loop

This fixes issue #156 and #181.