### PR TITLE
perf(vscode): fix slow response buffer

### DIFF
--- a/node/agent_sdk/protocol.ts
+++ b/node/agent_sdk/protocol.ts
@@ -80,13 +80,53 @@ export interface ReplayStream {
   result: Promise<ReplayResult>;
 }
 
+// Simple linked-list node for O(1) enqueue/dequeue.
+class _QueueNode<T> {
+  value: T;
+  next: _QueueNode<T> | null = null;
+  constructor(value: T) {
+    this.value = value;
+  }
+}
+
+// O(1) enqueue / dequeue queue to avoid the O(n) cost of Array.prototype.shift().
+class _EventQueue<T> {
+  private head: _QueueNode<T> | null = null;
+  private tail: _QueueNode<T> | null = null;
+  private _size = 0;
+
+  get size(): number {
+    return this._size;
+  }
+
+  enqueue(value: T): void {
+    const node = new _QueueNode(value);
+    if (this.tail) {
+      this.tail.next = node;
+    } else {
+      this.head = node;
+    }
+    this.tail = node;
+    this._size++;
+  }
+
+  dequeue(): T | undefined {
+    if (!this.head) return undefined;
+    const value = this.head.value;
+    this.head = this.head.next;
+    if (!this.head) this.tail = null;
+    this._size--;
+    return value;
+  }
+}
+
 // Event Channel Helper
 export function createEventChannel<T>(): {
   iterable: AsyncIterable<T>;
   push: (value: T) => void;
   finish: () => void;
 } {
-  const queue: T[] = [];
+  const queue = new _EventQueue<T>();
   const resolvers: Array<(result: IteratorResult<T>) => void> = [];
   let finished = false;
 
@@ -94,7 +134,7 @@ export function createEventChannel<T>(): {
     iterable: {
       [Symbol.asyncIterator]: () => ({
         next: () => {
-          const queued = queue.shift();
+          const queued = queue.dequeue();
           if (queued !== undefined) {
             return Promise.resolve({ done: false as const, value: queued });
           }
@@ -113,7 +153,7 @@ export function createEventChannel<T>(): {
       if (resolver) {
         resolver({ done: false, value });
       } else {
-        queue.push(value);
+        queue.enqueue(value);
       }
     },
     finish: () => {

--- a/node/vscode_extension/src/handlers/chat.handler.ts
+++ b/node/vscode_extension/src/handlers/chat.handler.ts
@@ -174,12 +174,39 @@ const streamChat: Handler<StreamChatParams, { done: boolean }> = async (params, 
   const pendingToolCalls = new Map<string, PendingToolCall>();
   let lastToolCallId: string | null = null;
 
+  let result: RunResult = { status: "finished" };
+  let eventCount = 0;
+
+  // Batch high-frequency streaming events (ContentPart / ToolCallPart) to
+  // reduce postMessage overhead and allow React to batch re-renders.
+  const BATCHABLE_TYPES = new Set(["ContentPart", "ToolCallPart"]);
+  const MAX_BATCH_SIZE = 50;
+  const MAX_BATCH_WAIT_MS = 16;
+  let eventBuffer: any[] = [];
+  let batchTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function flushBuffer() {
+    batchTimer = null;
+    if (eventBuffer.length === 0) return;
+    const batch = eventBuffer;
+    eventBuffer = [];
+    ctx.broadcast(
+      Events.StreamEvent,
+      batch.map((e) => ({ ...e, _sessionId: sessionId })),
+      ctx.webviewId,
+    );
+  }
+
+  function clearBatchTimer() {
+    if (batchTimer) {
+      clearTimeout(batchTimer);
+      batchTimer = null;
+    }
+  }
+
   try {
     const turn = session.prompt(contentWithContext);
     ctx.setTurn(turn);
-
-    let result: RunResult = { status: "finished" };
-    let eventCount = 0;
 
     for await (const event of turn) {
       // Yield to the event loop every 100 events so that I/O (e.g.
@@ -233,8 +260,28 @@ const streamChat: Handler<StreamChatParams, { done: boolean }> = async (params, 
         }
       }
 
-      ctx.broadcast(Events.StreamEvent, { ...event, _sessionId: sessionId }, ctx.webviewId);
+      // Batching logic: flush existing buffer when a non-batchable event arrives
+      if (!BATCHABLE_TYPES.has(eventType) && eventBuffer.length > 0) {
+        clearBatchTimer();
+        flushBuffer();
+      }
+
+      if (BATCHABLE_TYPES.has(eventType)) {
+        eventBuffer.push(event);
+        if (eventBuffer.length >= MAX_BATCH_SIZE) {
+          clearBatchTimer();
+          flushBuffer();
+        } else if (!batchTimer) {
+          batchTimer = setTimeout(flushBuffer, MAX_BATCH_WAIT_MS);
+        }
+      } else {
+        ctx.broadcast(Events.StreamEvent, { ...event, _sessionId: sessionId }, ctx.webviewId);
+      }
     }
+
+    // Flush any remaining batched events
+    clearBatchTimer();
+    flushBuffer();
 
     result = await turn.result;
 
@@ -244,6 +291,8 @@ const streamChat: Handler<StreamChatParams, { done: boolean }> = async (params, 
     return { done: true };
   } catch (err) {
     ctx.setTurn(null);
+    clearBatchTimer();
+    flushBuffer();
 
     const code = getErrorCode(err);
     const phase = classifyError(code);

--- a/node/vscode_extension/src/handlers/chat.handler.ts
+++ b/node/vscode_extension/src/handlers/chat.handler.ts
@@ -179,8 +179,16 @@ const streamChat: Handler<StreamChatParams, { done: boolean }> = async (params, 
     ctx.setTurn(turn);
 
     let result: RunResult = { status: "finished" };
+    let eventCount = 0;
 
     for await (const event of turn) {
+      // Yield to the event loop every 100 events so that I/O (e.g.
+      // readline consuming stdout from the CLI) does not starve when
+      // the createEventChannel queue is large.
+      if (++eventCount % 100 === 0) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
+
       const eventAny = event as any;
       const eventType = event.type;
       const payload = eventAny.payload;

--- a/node/vscode_extension/webview-ui/src/App.tsx
+++ b/node/vscode_extension/webview-ui/src/App.tsx
@@ -16,25 +16,37 @@ import type { UIStreamEvent, StreamError, ExtensionConfig } from "shared/types";
 import "./styles/index.css";
 
 function MainContent({ onAuthAction }: { onAuthAction: () => void }) {
-  const { processEvent, startNewConversation, sessionId } = useChatStore();
+  const { processEvent, processEvents, startNewConversation, sessionId } = useChatStore();
   const { setMCPServers, setExtensionConfig, extensionConfig } = useSettingsStore();
 
   useEffect(() => {
-    return bridge.on(Events.StreamEvent, (event: UIStreamEvent) => {
-      // 只有当前已有 session 时才过滤，确保 session_start 能正常处理
-      if (sessionId && "_sessionId" in event && event._sessionId && event._sessionId !== sessionId) {
-        console.log("Ignored stream event from another session:", event._sessionId);
-        return;
+    return bridge.on(Events.StreamEvent, (data: UIStreamEvent | UIStreamEvent[]) => {
+      const events = Array.isArray(data) ? data : [data];
+      // Filter out events from other sessions
+      const validEvents = events.filter((event) => {
+        // 只有当前已有 session 时才过滤，确保 session_start 能正常处理
+        if (sessionId && "_sessionId" in event && event._sessionId && event._sessionId !== sessionId) {
+          console.log("Ignored stream event from another session:", event._sessionId);
+          return false;
+        }
+        return true;
+      });
+      if (validEvents.length === 0) return;
+      if (validEvents.length === 1) {
+        processEvent(validEvents[0]);
+      } else {
+        processEvents(validEvents);
       }
-      processEvent(event);
-      if (event.type === "error") {
-        const streamError = event as StreamError;
-        if (isPreflightError(streamError.code || "UNKNOWN")) {
-          toast.error(streamError.message);
+      for (const event of validEvents) {
+        if (event.type === "error") {
+          const streamError = event as StreamError;
+          if (isPreflightError(streamError.code || "UNKNOWN")) {
+            toast.error(streamError.message);
+          }
         }
       }
     });
-  }, [processEvent, sessionId]);
+  }, [processEvent, processEvents, sessionId]);
 
   useEffect(() => {
     const unsubs = [

--- a/node/vscode_extension/webview-ui/src/components/ChatArea.tsx
+++ b/node/vscode_extension/webview-ui/src/components/ChatArea.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import ScrollToBottom, { useScrollToBottom, useSticky } from "react-scroll-to-bottom";
 import { IconArrowDown } from "@tabler/icons-react";
 import { ChatMessage } from "./ChatMessage";
@@ -24,16 +25,24 @@ function ScrollButton() {
 function MessageList() {
   const { messages, isStreaming } = useChatStore();
 
-  // Calculate turn index for each assistant message
-  // Turn index is 0-indexed, counting user messages
-  const getTurnIndex = (idx: number): number | undefined => {
-    if (messages[idx]?.role !== "assistant") return undefined;
-    let turnCount = 0;
-    for (let i = 0; i < idx; i++) {
-      if (messages[i].role === "user") turnCount++;
+  // Precompute turn indices in O(n) instead of O(n²) per render.
+  // turnIndices[i] is the turn index for messages[i] when it is an assistant
+  // message, otherwise undefined.
+  const turnIndices = useMemo<(number | undefined)[]>(() => {
+    const indices: (number | undefined)[] = [];
+    let userCount = 0;
+    for (let i = 0; i < messages.length; i++) {
+      if (messages[i].role === "assistant") {
+        indices.push(userCount - 1);
+      } else {
+        indices.push(undefined);
+      }
+      if (messages[i].role === "user") {
+        userCount++;
+      }
     }
-    return turnCount - 1; // 0-indexed (first turn = 0)
-  };
+    return indices;
+  }, [messages]);
 
   return (
     <>
@@ -42,7 +51,7 @@ function MessageList() {
           <ChatMessage
             key={message.id}
             message={message}
-            turnIndex={getTurnIndex(idx)}
+            turnIndex={turnIndices[idx]}
             isStreaming={isStreaming && idx === messages.length - 1 && message.role === "assistant"}
           />
         ))}

--- a/node/vscode_extension/webview-ui/src/components/ChatMessage.tsx
+++ b/node/vscode_extension/webview-ui/src/components/ChatMessage.tsx
@@ -1,4 +1,4 @@
-import { useState, Fragment } from "react";
+import { useState, Fragment, memo } from "react";
 import { IconLoader3, IconGitFork } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import { Content } from "@/lib/content";
@@ -144,7 +144,10 @@ interface ForkButtonProps {
 function ForkButton({ turnIndex, className }: ForkButtonProps) {
   const [showConfirm, setShowConfirm] = useState(false);
   const [isForking, setIsForking] = useState(false);
-  const { sessionId, isStreaming, loadSession, abort } = useChatStore();
+  const sessionId = useChatStore((state) => state.sessionId);
+  const isStreaming = useChatStore((state) => state.isStreaming);
+  const loadSession = useChatStore((state) => state.loadSession);
+  const abort = useChatStore((state) => state.abort);
 
   const handleFork = () => {
     if (!sessionId || turnIndex < 0) return;
@@ -239,7 +242,7 @@ function UserMessage({ message }: { message: ChatMessageType }) {
 
 function AssistantMessage({ message, turnIndex, isStreaming }: { message: ChatMessageType; turnIndex?: number; isStreaming?: boolean }) {
   const [previewMedia, setPreviewMedia] = useState<string | null>(null);
-  const { isCompacting } = useChatStore();
+  const isCompacting = useChatStore((state) => state.isCompacting);
 
   const steps = message.steps || [];
   const hasSteps = steps.length > 0;
@@ -335,9 +338,9 @@ function hasMessageContent(message: ChatMessageType): boolean {
   return message.steps?.some((s) => s.items.length > 0) ?? false;
 }
 
-export function ChatMessage({ message, turnIndex, isStreaming }: ChatMessageProps) {
+export const ChatMessage = memo(function ChatMessage({ message, turnIndex, isStreaming }: ChatMessageProps) {
   if (message.role === "user") {
     return <UserMessage message={message} />;
   }
   return <AssistantMessage message={message} turnIndex={turnIndex} isStreaming={isStreaming} />;
-}
+});

--- a/node/vscode_extension/webview-ui/src/stores/chat.store.ts
+++ b/node/vscode_extension/webview-ui/src/stores/chat.store.ts
@@ -102,6 +102,7 @@ export interface ChatState {
   sendMessage: (text: string) => void;
   retryLastMessage: () => void;
   processEvent: (event: UIStreamEvent) => void;
+  processEvents: (events: UIStreamEvent[]) => void;
   loadSession: (sessionId: string, events: UIStreamEvent[]) => Promise<void>;
   startNewConversation: () => Promise<void>;
   abort: () => void;
@@ -235,20 +236,39 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   processEvent: (event) => {
-    // Clear handshake timeout on receiving valid response
-    if (event.type === "TurnBegin" || event.type === "StepBegin" || event.type === "ContentPart") {
+    get().processEvents([event]);
+  },
+
+  processEvents: (events) => {
+    let needHandshake = false;
+    let needAutoSend = false;
+
+    for (const event of events) {
+      if (event.type === "TurnBegin" || event.type === "StepBegin" || event.type === "ContentPart") {
+        needHandshake = true;
+      }
+      if (event.type === "stream_complete" || event.type === "error") {
+        needAutoSend = true;
+      }
+    }
+
+    if (needHandshake) {
       clearHandshakeTimer();
-      set({ handshakeReceived: true });
     }
 
     set(
       produce((draft: ChatState) => {
-        processEvent(draft, event);
+        if (needHandshake) {
+          draft.handshakeReceived = true;
+        }
+        for (const event of events) {
+          processEvent(draft, event);
+        }
       }),
     );
 
     // Auto-send next queued item when streaming ends (complete or error)
-    if (event.type === "stream_complete" || event.type === "error") {
+    if (needAutoSend) {
       const { queue, isStreaming: stillStreaming } = get();
       if (!stillStreaming && queue.length > 0) {
         setTimeout(() => get().sendNextQueued(), 50);


### PR DESCRIPTION
**Summary**
Improves rendering performance during high-frequency streaming events in the VS Code extension by replacing the O(n) array queue, batching IPC messages, and cutting per-token React overhead.

Fixes #156. Should mitigate #181 too, but the real fix for that would be to decouple the JSON RPC response from the write queue  in [kimi-cli](https://github.com/MoonshotAI/kimi-cli).

**Changes**

*Extension host*
- Replaced `Array.prototype.shift()` queue with an O(1) linked-list event channel.
- Added cooperative yielding every 100 events to prevent I/O starvation on large queues.
- Batches `ContentPart` / `ToolCallPart` events (max 50 events or 16 ms) before `webview.postMessage`; non-batchable events flush immediately. This reduces IPC pressure and lets React batch re-renders.

*Webview*
- Added `processEvents()` to apply N events inside a single Immer `produce()` draft, eliminating intermediate state objects and Zustand subscriber churn.
- `App.tsx` now accepts `UIStreamEvent | UIStreamEvent[]` from bridge messages and routes batches to `processEvents()`.
- Wrapped `ChatMessage` in `React.memo` and replaced bare `useChatStore()` with selective Zustand selectors so old messages stop re-rendering on streaming.
- Replaced O(n²) `getTurnIndex()` in `ChatArea` with a `useMemo`-precomputed `turnIndices` map in O(n).

**Testing**
- `tsc --noEmit` clean across affected packages.
- 256 `agent_sdk` tests pass.