### PR TITLE
fix(jsonrpc2): stop panicking when a stream payload races StreamOpen init

### DIFF
--- a/go/wire/jsonrpc2/codec.go
+++ b/go/wire/jsonrpc2/codec.go
@@ -324,7 +324,27 @@ func (c *Codec) recv() {
 					continue
 				}
 				if receiver == nil {
-					panic("receiver is nil")
+					// `c.receivers[id] = nil` is the placeholder set at the
+					// top of `recv()` (search for `c.receivers[payload.ID] =
+					// nil`) when a StreamOpen payload arrives. The real
+					// channel is only installed later, on a different
+					// goroutine, when the request handler runs
+					// `receiver.Receiver(...)`. Between those two points, any
+					// follow-up stream payload for the same id reaches this
+					// branch with `ok == true` and `receiver == nil`. The
+					// previous behaviour panicked the codec goroutine, which
+					// kills the entire session for what is in fact a benign
+					// in-flight initialisation race.
+					//
+					// Requeue with a small delay so consumependings picks the
+					// payload back up once the handler has installed the real
+					// channel — same recovery shape as the `<-time.After`
+					// timeout branch a few lines below, but gated on a fixed
+					// 10ms tick so we don't hot-spin if the handler is slow.
+					time.AfterFunc(10*time.Millisecond, func() {
+						go requeue(receiverid)
+					})
+					continue
 				}
 				if payload.Stream == StreamClose {
 					c.receiverlock.Lock()


### PR DESCRIPTION
## What

`recv()` in `go/wire/jsonrpc2/codec.go` reacts to a `StreamOpen` payload by registering a placeholder entry in the receiver map:

```go
if payload.Stream == StreamOpen {
    c.receiverlock.Lock()
    c.receivers[payload.ID] = nil   // ← placeholder, real channel comes later
    c.receiverlock.Unlock()
    go c.watchidle(payload.ID)
}
```

The real channel is only installed later, on a **different goroutine**, when the request handler runs `receiver.Receiver(...)` (line 442 for requests, 616 for responses). Between those two points, any follow-up stream payload for the same id lands in `consumependings()` with `ok == true` and `receiver == nil`:

```go
receiver, ok := c.receivers[payload.ID]
...
if receiver == nil {
    panic("receiver is nil")   // ← session dies
}
```

The protocol explicitly allows the StreamOpen → first StreamData ordering to land back-to-back (callers stream `StreamOpen → data → data → ... → StreamClose`), so this race is reachable in normal traffic — and panicking takes down the entire codec goroutine for what is fundamentally a benign in-flight initialisation race.

## Fix

Requeue the payload instead of panicking, gated on a 10 ms `time.AfterFunc` tick so we don't hot-spin if the handler is slow installing the real channel. Same recovery shape as the existing `<-time.After(timeout)` branch a few lines below, which already requeues when a send into a receiver blocks.

```go
if receiver == nil {
    time.AfterFunc(10*time.Millisecond, func() {
        go requeue(receiverid)
    })
    continue
}
```

The fdlist element stays in place (we didn't call `rmelement`), so when `consumependings` picks up the requeued waker it finds the same payload again. If the handler is slow we tick at ~100 Hz per stuck stream — orders of magnitude cheaper than dropping the session.

## Verification

- `go build ./...` passes
- `go test ./wire/jsonrpc2/... -race` passes (`ok  github.com/MoonshotAI/kimi-agent-sdk/go/wire/jsonrpc2  11.455s`)
- The only code path changed is the one that previously panicked, so all happy-path tests still exercise the original behaviour
