### PR TITLE
fix(vscode): ignore non-file drag events

### DIFF
--- a/node/vscode_extension/package.json
+++ b/node/vscode_extension/package.json
@@ -95,7 +95,11 @@
         "kimi.editorContext": {
           "type": "string",
           "default": "never",
-          "enum": ["never", "onConversationStart", "onFileChange"],
+          "enum": [
+            "never",
+            "onConversationStart",
+            "onFileChange"
+          ],
           "enumDescriptions": [
             "Never share editor context",
             "Share once when conversation starts",
@@ -244,7 +248,7 @@
   },
   "scripts": {
     "vscode:prepublish": "pnpm run build",
-    "dev": "DEBUG=kimi-sdk:* node dev.js",
+    "dev": "node dev.js",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
     "build": "pnpm run build:webview && pnpm run build:extension",

--- a/node/vscode_extension/webview-ui/src/components/inputarea/hooks/useMediaUpload.ts
+++ b/node/vscode_extension/webview-ui/src/components/inputarea/hooks/useMediaUpload.ts
@@ -108,13 +108,20 @@ export function useMediaUpload(): UseMediaUploadResult {
 
   useEffect(() => {
     const isMediaFile = (file: File) => getMediaType(file) !== null;
+    const hasFiles = (event: DragEvent) => event.dataTransfer?.types.includes("Files") ?? false;
 
     const handleDocDragEnter = (e: DragEvent) => {
+      if (!hasFiles(e)) {
+        return;
+      }
       e.preventDefault();
       e.stopPropagation();
     };
 
     const handleDocDragOver = (e: DragEvent) => {
+      if (!hasFiles(e)) {
+        return;
+      }
       e.preventDefault();
       e.stopPropagation();
       if (e.dataTransfer) {
@@ -123,6 +130,9 @@ export function useMediaUpload(): UseMediaUploadResult {
     };
 
     const handleDocDrop = (e: DragEvent) => {
+      if (!hasFiles(e)) {
+        return;
+      }
       e.preventDefault();
       e.stopPropagation();
       if (hasProcessing) {


### PR DESCRIPTION
## Problem
Resizing the Kimi Code sidebar can make the chat panel appear frozen. The issue is most visible while dragging the VS Code sidebar sash next to the Webview.

## Root Cause
The media-upload hook registered document-level `dragenter`, `dragover`, and `drop` handlers so users could drag media files into the chat. Those handlers treated every drag gesture as a file drop: each `dragenter` and `dragover` unconditionally called `preventDefault()` and `stopPropagation()`.

VS Code layout resizing can deliver drag events to the Webview document. Because the handlers did not inspect the drag payload, they intercepted these non-file, high-frequency resize events and forced file-drop behavior onto a native layout interaction. That prevents the normal resize interaction from propagating correctly and leaves the chat UI unresponsive.

## Fix
Only handle drag events whose `DataTransfer.types` includes `Files`.

- File drags still prevent the browser default and show the copy drop effect.
- Non-file drags, including VS Code layout resizing, are ignored by the Webview and continue through the normal VS Code event path.
- The same guard is applied consistently to `dragenter`, `dragover`, and `drop`.

## Verification
- `pnpm --dir node/vscode_extension typecheck`
- `pnpm --dir node/vscode_extension lint`
- `pnpm --dir node/vscode_extension build`
- `pnpm --dir node exec prettier --check vscode_extension/webview-ui/src/components/inputarea/hooks/useMediaUpload.ts`