### PR TITLE
fix(vscode): separate file picker trigger

### DIFF
--- a/node/vscode_extension/webview-ui/src/components/inputarea/InputArea.tsx
+++ b/node/vscode_extension/webview-ui/src/components/inputarea/InputArea.tsx
@@ -273,7 +273,8 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
   };
 
   const handleAddButtonClick = useMemoizedFn(() => {
-    const newText = text + "@";
+    const separator = text && !/\s$/.test(text) ? " " : "";
+    const newText = text + separator + "@";
     setText(newText);
     setCursorPos(newText.length);
     setTimeout(() => {


### PR DESCRIPTION
## Problem
Clicking the **Add files/media** button should open the `@` file-picker menu. When the message input already contained text without a trailing space, the button only appended a visible `@` and the picker did not open.

### Reproduction
1. Enter `Please inspect` in the chat input.
2. Click **Add files/media**.
3. The input becomes `Please inspect@`.
4. No file-picker menu is shown.

## Root Cause
The file-picker trigger is derived by `findActiveToken`. It examines the whitespace-delimited word immediately before the cursor and recognises a mention only when that word starts with `@`.

The button previously appended `@` directly to the input. In the example above, the parser receives `inspect@` as the current word, which does not start with `@`; it therefore returns no active file token and the file picker remains closed.

## Fix
Before appending the `@` trigger, add one space only when all of the following are true:

- The input is non-empty.
- The input does not already end in whitespace.

This turns `Please inspect` into `Please inspect @`, allowing the existing token parser and picker flow to work unchanged. Empty input and input ending in a space, newline, or tab retain the existing behavior and do not receive an extra space.

## Scope
The change is limited to the Add files/media button. It does not alter typed `@` mentions, file search, file insertion, or media upload behavior.

Fixes #76

## Verification
- `pnpm --dir node/vscode_extension typecheck`
- `pnpm --dir node/vscode_extension build:webview`
- `pnpm --dir node exec prettier --check vscode_extension/webview-ui/src/components/inputarea/InputArea.tsx`