### PR TITLE
fix(vscode): retry CLI cache cleanup

### DIFF
--- a/node/vscode_extension/src/managers/cli-downloader.ts
+++ b/node/vscode_extension/src/managers/cli-downloader.ts
@@ -168,7 +168,7 @@ export function copyUVWrapper(extensionPath: string, wrapperDir: string): void {
 
 function prepareDir(dir: string): void {
   if (fs.existsSync(dir)) {
-    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   }
   fs.mkdirSync(dir, { recursive: true });
 }


### PR DESCRIPTION
## Problem
On Windows, updating or initializing the bundled Kimi CLI can fail while cleaning the extension's cached CLI directory. The failure is surfaced as an installation/extraction error even though the archive itself is valid.

Typical errors include:

- `EPERM: permission denied` when removing the cached `bin/kimi` directory.
- `ENOTEMPTY` when a directory is briefly repopulated or released during recursive deletion.

These conditions can occur when a previous CLI process, VS Code, or the filesystem briefly retains a handle while the extension replaces the cached CLI before extraction.

## Root Cause
`prepareDir` used `fs.rmSync(..., { recursive: true, force: true })` with Node's default retry count of zero. On Windows, transient `EPERM`, `EBUSY`, and `ENOTEMPTY` failures therefore aborted the whole install instead of retrying the recursive cleanup.

## Fix
Configure the existing recursive cleanup with three retries and a 100 ms delay between attempts:

```ts
fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
```

Node applies these retries only to supported transient recursive-removal failures. Persistent locks still surface as an error rather than being hidden.

## Scope
This improves resilience while replacing the bundled CLI cache. It does not change CLI archive selection, authentication, or the separate ACP compatibility work required for the newer `kimi-code` CLI.

Related to #174 and #185.

## Verification
- `pnpm --dir node/vscode_extension typecheck`
- `pnpm --dir node/vscode_extension lint`
- `pnpm --dir node/vscode_extension build`
- `pnpm --dir node exec prettier --check vscode_extension/src/managers/cli-downloader.ts`