### PR TITLE
Add ACP support for current Kimi Code CLI

### DIFF
--- a/node/agent_sdk/acp-protocol.ts
+++ b/node/agent_sdk/acp-protocol.ts
@@ -1,10 +1,25 @@
 import { spawn, type ChildProcess } from "node:child_process";
 
-import type { ApprovalResponse, ContentPart, InitializeResult, RunResult, StreamEvent } from "./schema";
+import type { ApprovalResponse, ContentPart, InitializeResult, RunResult, SlashCommandInfo, StreamEvent } from "./schema";
+import { SlashCommandInfoSchema } from "./schema";
 import { ProtocolError, TransportError } from "./errors";
 import { createEventChannel, type ClientOptions, type PromptStream } from "./protocol";
 
 const ACP_PROTOCOL_VERSION = 1;
+
+function parseSlashCommands(raw: unknown): SlashCommandInfo[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const commands: SlashCommandInfo[] = [];
+  for (const item of raw) {
+    const parsed = SlashCommandInfoSchema.safeParse(item);
+    if (parsed.success) {
+      commands.push(parsed.data);
+    }
+  }
+  return commands;
+}
 
 interface PendingRequest {
   resolve: (value: unknown) => void;
@@ -92,7 +107,11 @@ export class AcpProtocolClient {
     const initialized = (await this.request("initialize", {
       protocolVersion: ACP_PROTOCOL_VERSION,
       clientCapabilities: {},
-    })) as { agentInfo?: { name?: string; version?: string } };
+    })) as {
+      agentInfo?: { name?: string; version?: string };
+      slashCommands?: unknown[];
+      slash_commands?: unknown[];
+    };
     const session = (await this.request(
       options.resumeSession && options.sessionId ? "session/load" : "session/new",
       options.resumeSession && options.sessionId
@@ -110,7 +129,7 @@ export class AcpProtocolClient {
     return {
       protocol_version: `acp/${ACP_PROTOCOL_VERSION}`,
       server: { name: initialized.agentInfo?.name ?? "Kimi Code CLI", version: initialized.agentInfo?.version ?? "unknown" },
-      slash_commands: [],
+      slash_commands: parseSlashCommands(initialized.slashCommands ?? initialized.slash_commands),
     };
   }
 

--- a/node/agent_sdk/acp-protocol.ts
+++ b/node/agent_sdk/acp-protocol.ts
@@ -1,0 +1,264 @@
+import { spawn, type ChildProcess } from "node:child_process";
+
+import type { ApprovalResponse, ContentPart, InitializeResult, RunResult, StreamEvent } from "./schema";
+import { TransportError } from "./errors";
+import { createEventChannel, type ClientOptions, type PromptStream } from "./protocol";
+
+const ACP_PROTOCOL_VERSION = 1;
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+}
+
+interface PendingApproval {
+  rpcId: string | number;
+  options: Array<{ optionId: string }>;
+}
+
+interface AcpToolCall {
+  toolCallId: string;
+  title?: string;
+  kind?: string;
+  rawInput?: unknown;
+  status?: string;
+  content?: unknown;
+}
+
+export interface AcpSessionConfig {
+  sessionId: string;
+  configOptions: Array<{
+    id?: string;
+    currentValue?: string;
+    options?: Array<{ value: string; name: string }>;
+  }>;
+}
+
+export class AcpProtocolClient {
+  private process: ChildProcess | null = null;
+  private requestId = 0;
+  private sessionId: string | null = null;
+  private pendingRequests = new Map<string | number, PendingRequest>();
+  private pendingApprovals = new Map<string, PendingApproval>();
+  private toolCalls = new Map<string, AcpToolCall>();
+  private eventChannel: ReturnType<typeof createEventChannel<StreamEvent>> | null = null;
+  private config: AcpSessionConfig | null = null;
+
+  get sessionConfig(): AcpSessionConfig | null {
+    return this.config;
+  }
+
+  get isRunning(): boolean {
+    return this.process !== null && this.process.exitCode === null;
+  }
+
+  async start(options: ClientOptions): Promise<InitializeResult> {
+    const executable = options.executablePath ?? "kimi";
+    this.process = spawn(executable, ["acp"], {
+      cwd: options.workDir,
+      env: { ...process.env, ...options.environmentVariables },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    if (!this.process.stdin || !this.process.stdout) {
+      throw new TransportError("SPAWN_FAILED", "ACP process missing stdio");
+    }
+
+    let buffer = "";
+    this.process.stdout.on("data", (chunk) => {
+      buffer += chunk.toString();
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) this.handleLine(line);
+    });
+    this.process.on("exit", () => this.finishEvents());
+    this.process.on("error", (error) => this.finishEvents(error));
+
+    const initialized = (await this.request("initialize", {
+      protocolVersion: ACP_PROTOCOL_VERSION,
+      clientCapabilities: {},
+    })) as { agentInfo?: { name?: string; version?: string } };
+    const session = (await this.request("session/new", { cwd: options.workDir, mcpServers: [] })) as AcpSessionConfig;
+    this.sessionId = session.sessionId;
+    this.config = session;
+    await this.applySessionOptions(options);
+
+    return {
+      protocol_version: `acp/${ACP_PROTOCOL_VERSION}`,
+      server: { name: initialized.agentInfo?.name ?? "Kimi Code CLI", version: initialized.agentInfo?.version ?? "unknown" },
+      slash_commands: [],
+    };
+  }
+
+  sendPrompt(content: string | ContentPart[]): PromptStream {
+    const channel = createEventChannel<StreamEvent>();
+    this.eventChannel = channel;
+    channel.push({ type: "TurnBegin", payload: { user_input: content } });
+    const prompt = typeof content === "string" ? [{ type: "text", text: content }] : content.filter((part) => part.type === "text").map((part) => ({ type: "text", text: part.text }));
+    const result = this.request("session/prompt", { sessionId: this.sessionId, prompt })
+      .then((): RunResult => ({ status: "finished" }))
+      .finally(() => {
+        channel.push({ type: "TurnEnd", payload: {} });
+        this.finishEvents();
+      });
+    return { events: channel.iterable, result };
+  }
+
+  sendCancel(): Promise<void> {
+    return this.request("session/cancel", { sessionId: this.sessionId }).then(() => {});
+  }
+
+  sendApproval(requestId: string, response: ApprovalResponse): Promise<void> {
+    const pending = this.pendingApprovals.get(requestId);
+    if (!pending) return Promise.resolve();
+    this.pendingApprovals.delete(requestId);
+    const optionId = response === "approve" ? "approve_once" : response === "approve_for_session" ? "approve_always" : "reject";
+    const selected = pending.options.find((option) => option.optionId === optionId) ?? pending.options.at(-1);
+    this.write({
+      jsonrpc: "2.0",
+      id: pending.rpcId,
+      result: { outcome: selected ? { outcome: "selected", optionId: selected.optionId } : { outcome: "cancelled" } },
+    });
+    return Promise.resolve();
+  }
+
+  async stop(): Promise<void> {
+    if (!this.process) return;
+    this.process.kill("SIGTERM");
+    this.process = null;
+    this.finishEvents();
+  }
+
+  private request(method: string, params: unknown): Promise<unknown> {
+    const id = ++this.requestId;
+    return new Promise((resolve, reject) => {
+      this.pendingRequests.set(id, { resolve, reject });
+      try {
+        this.write({ jsonrpc: "2.0", id, method, params });
+      } catch (error) {
+        this.pendingRequests.delete(id);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
+
+  private write(message: unknown): void {
+    if (!this.process?.stdin?.writable) throw new TransportError("STDIN_NOT_WRITABLE", "Cannot write to ACP CLI stdin");
+    this.process.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  private handleLine(line: string): void {
+    if (!line.trim()) return;
+    let message: any;
+    try { message = JSON.parse(line); } catch { return; }
+    if (message.id !== undefined && this.pendingRequests.has(message.id)) {
+      const pending = this.pendingRequests.get(message.id)!;
+      this.pendingRequests.delete(message.id);
+      if (message.error) pending.reject(new Error(message.error.message)); else pending.resolve(message.result);
+      return;
+    }
+    if (message.method === "session/update") this.handleUpdate(message.params);
+    if (message.method === "session/request_permission") this.handleApproval(message);
+  }
+
+  private handleUpdate(params: any): void {
+    const update = params?.update;
+    if (!update || !this.eventChannel) return;
+    for (const event of mapAcpUpdate(update, this.toolCalls)) this.eventChannel.push(event);
+  }
+
+  private handleApproval(message: any): void {
+    const params = message.params;
+    const requestId = String(message.id);
+    this.pendingApprovals.set(requestId, { rpcId: message.id, options: params?.options ?? [] });
+    this.eventChannel?.push({ type: "ApprovalRequest", payload: { id: requestId, tool_call_id: params?.toolCall?.toolCallId ?? "acp", sender: params?.toolCall?.title ?? "Tool", action: "execute tool", description: params?.toolCall?.title ?? "Approval required" } });
+  }
+
+  private finishEvents(error?: Error): void {
+    if (error) for (const pending of this.pendingRequests.values()) pending.reject(error);
+    this.pendingRequests.clear();
+    this.pendingApprovals.clear();
+    this.toolCalls.clear();
+    this.eventChannel?.finish();
+    this.eventChannel = null;
+  }
+
+  private async applySessionOptions(options: ClientOptions): Promise<void> {
+    const configOptions = this.config?.configOptions ?? [];
+    const apply = async (configId: string, value: string | undefined): Promise<void> => {
+      if (!value) return;
+      const option = configOptions.find((item) => item.id === configId);
+      if (!option || option.currentValue === value || !option.options?.some((item) => item.value === value)) return;
+      await this.request("session/set_config_option", { sessionId: this.sessionId, configId, value });
+      option.currentValue = value;
+    };
+
+    await apply("model", options.model);
+    await apply("thinking", options.thinking ? "on" : "off");
+    await apply("mode", options.yoloMode ? "yolo" : "default");
+  }
+}
+
+/** Convert ACP session updates to the SDK's existing Wire-compatible event contract. */
+export function mapAcpUpdate(update: any, toolCalls = new Map<string, AcpToolCall>()): StreamEvent[] {
+  if (update.sessionUpdate === "agent_message_chunk" && typeof update.content?.text === "string") {
+    return [{ type: "ContentPart", payload: { type: "text", text: update.content.text } }];
+  }
+  if (update.sessionUpdate === "agent_thought_chunk" && typeof update.content?.text === "string") {
+    return [{ type: "ContentPart", payload: { type: "think", think: update.content.text } }];
+  }
+
+  if (update.sessionUpdate === "tool_call") {
+    const tool = update as AcpToolCall;
+    if (!tool.toolCallId) return [];
+    toolCalls.set(tool.toolCallId, tool);
+    return [{
+      type: "ToolCall",
+      payload: {
+        type: "function",
+        id: tool.toolCallId,
+        function: { name: tool.title ?? tool.kind ?? "Tool", arguments: stringifyToolInput(tool.rawInput) },
+        extras: { title: tool.title, kind: tool.kind, status: tool.status },
+      },
+    }];
+  }
+
+  if (update.sessionUpdate === "tool_call_update") {
+    const tool = update as AcpToolCall;
+    const previous = toolCalls.get(tool.toolCallId) ?? { toolCallId: tool.toolCallId };
+    const current = { ...previous, ...tool };
+    toolCalls.set(tool.toolCallId, current);
+    if (!tool.toolCallId) return [];
+    if (tool.status === "completed" || tool.status === "failed") {
+      return [{
+        type: "ToolResult",
+        payload: {
+          tool_call_id: tool.toolCallId,
+          return_value: {
+            is_error: tool.status === "failed",
+            output: stringifyToolOutput(current.content),
+            message: tool.status === "failed" ? "Tool call failed" : "Tool call completed",
+            display: [],
+          },
+        },
+      }];
+    }
+    return [{ type: "StatusUpdate", payload: {} }];
+  }
+
+  if (update.sessionUpdate === "plan") {
+    return [{ type: "StatusUpdate", payload: { plan_mode: true } }];
+  }
+  return [];
+}
+
+function stringifyToolInput(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+function stringifyToolOutput(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === undefined || value === null) return "";
+  return JSON.stringify(value);
+}

--- a/node/agent_sdk/acp-protocol.ts
+++ b/node/agent_sdk/acp-protocol.ts
@@ -34,6 +34,10 @@ export interface AcpSessionConfig {
   }>;
 }
 
+interface AcpPromptResponse {
+  stopReason?: string;
+}
+
 type AcpSessionResult = Omit<AcpSessionConfig, "sessionId"> & { sessionId?: string };
 
 function toAcpSessionId(sessionId: string): string {
@@ -118,7 +122,7 @@ export class AcpProtocolClient {
     channel.push({ type: "StepBegin", payload: { n: 1 } });
     const prompt = typeof content === "string" ? [{ type: "text", text: content }] : content.filter((part) => part.type === "text").map((part) => ({ type: "text", text: part.text }));
     const result = this.request("session/prompt", { sessionId: this.sessionId, prompt })
-      .then((): RunResult => ({ status: "finished" }))
+      .then((response): RunResult => this.toRunResult(response as AcpPromptResponse))
       .finally(() => {
         channel.push({ type: "TurnEnd", payload: {} });
         this.finishEvents();
@@ -194,6 +198,37 @@ export class AcpProtocolClient {
     const requestId = String(message.id);
     this.pendingApprovals.set(requestId, { rpcId: message.id, options: params?.options ?? [] });
     this.eventChannel?.push({ type: "ApprovalRequest", payload: { id: requestId, tool_call_id: params?.toolCall?.toolCallId ?? "acp", sender: params?.toolCall?.title ?? "Tool", action: "execute tool", description: params?.toolCall?.title ?? "Approval required" } });
+  }
+
+  private toRunResult(response: AcpPromptResponse): RunResult {
+    const stopReason = response.stopReason;
+    const pendingToolCallIds = [...this.toolCalls.values()]
+      .filter((tool) => tool.status !== "completed" && tool.status !== "failed")
+      .map((tool) => tool.toolCallId);
+
+    console.warn("[kimi-code] ACP prompt completed", {
+      sessionId: this.sessionId,
+      stopReason,
+      pendingToolCallIds,
+    });
+
+    if (stopReason === "cancelled") {
+      return { status: "cancelled" };
+    }
+
+    if (stopReason === "max_steps") {
+      return { status: "max_steps_reached" };
+    }
+
+    if (pendingToolCallIds.length > 0) {
+      throw new ProtocolError(
+        "INCOMPLETE_TURN",
+        `Kimi Code ended the ACP turn before completing tool calls: ${pendingToolCallIds.join(", ")}`,
+        { sessionId: this.sessionId ?? undefined, stopReason, pendingToolCallIds },
+      );
+    }
+
+    return { status: "finished" };
   }
 
   private finishEvents(error?: Error): void {

--- a/node/agent_sdk/acp-protocol.ts
+++ b/node/agent_sdk/acp-protocol.ts
@@ -23,6 +23,7 @@ interface AcpToolCall {
   rawInput?: unknown;
   status?: string;
   content?: unknown;
+  argumentText?: string;
 }
 
 export interface AcpSessionConfig {
@@ -271,13 +272,14 @@ export function mapAcpUpdate(update: any, toolCalls = new Map<string, AcpToolCal
   if (update.sessionUpdate === "tool_call") {
     const tool = update as AcpToolCall;
     if (!tool.toolCallId) return [];
-    toolCalls.set(tool.toolCallId, tool);
+    const argumentText = stringifyToolInput(tool.rawInput) ?? acpContentText(tool.content);
+    toolCalls.set(tool.toolCallId, { ...tool, argumentText });
     return [{
       type: "ToolCall",
       payload: {
         type: "function",
         id: tool.toolCallId,
-        function: { name: tool.title ?? tool.kind ?? "Tool", arguments: stringifyToolInput(tool.rawInput) },
+        function: { name: tool.title ?? tool.kind ?? "Tool", arguments: argumentText },
         extras: { title: tool.title, kind: tool.kind, status: tool.status },
       },
     }];
@@ -286,7 +288,10 @@ export function mapAcpUpdate(update: any, toolCalls = new Map<string, AcpToolCal
   if (update.sessionUpdate === "tool_call_update") {
     const tool = update as AcpToolCall;
     const previous = toolCalls.get(tool.toolCallId) ?? { toolCallId: tool.toolCallId };
-    const current = { ...previous, ...tool };
+    const argumentText = tool.rawInput !== undefined
+      ? stringifyToolInput(tool.rawInput)
+      : acpContentText(tool.content) ?? previous.argumentText;
+    const current = { ...previous, ...tool, argumentText };
     toolCalls.set(tool.toolCallId, current);
     if (!tool.toolCallId) return [];
     if (tool.status === "completed" || tool.status === "failed") {
@@ -303,7 +308,15 @@ export function mapAcpUpdate(update: any, toolCalls = new Map<string, AcpToolCal
         },
       }];
     }
-    return [{ type: "StatusUpdate", payload: {} }];
+    const events: StreamEvent[] = [];
+    if (argumentText !== undefined && argumentText !== previous.argumentText) {
+      events.push({
+        type: "ToolCallPart",
+        payload: { tool_call_id: tool.toolCallId, arguments_part: argumentText, replace_arguments: true },
+      });
+    }
+    events.push({ type: "StatusUpdate", payload: {} });
+    return events;
   }
 
   if (update.sessionUpdate === "plan") {
@@ -318,7 +331,25 @@ function stringifyToolInput(value: unknown): string | undefined {
 }
 
 function stringifyToolOutput(value: unknown): string {
-  if (typeof value === "string") return value;
+  const contentText = acpContentText(value);
+  if (contentText !== undefined) return contentText;
   if (value === undefined || value === null) return "";
   return JSON.stringify(value);
+}
+
+function acpContentText(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (!Array.isArray(value)) return undefined;
+
+  const text = value.flatMap((item) => {
+    if (!item || typeof item !== "object") return [];
+    const content = (item as { content?: unknown }).content;
+    if (typeof content === "string") return [content];
+    if (content && typeof content === "object" && typeof (content as { text?: unknown }).text === "string") {
+      return [(content as { text: string }).text];
+    }
+    if (typeof (item as { text?: unknown }).text === "string") return [(item as { text: string }).text];
+    return [];
+  });
+  return text.length > 0 ? text.join("\n") : undefined;
 }

--- a/node/agent_sdk/acp-protocol.ts
+++ b/node/agent_sdk/acp-protocol.ts
@@ -178,14 +178,23 @@ export class AcpProtocolClient {
     if (!line.trim()) return;
     let message: any;
     try { message = JSON.parse(line); } catch { return; }
+    // ACP is bidirectional JSON-RPC: an agent-side request may reuse the
+    // numeric ID of one of our outstanding requests. Dispatch methods before
+    // looking at the ID so a reverse permission request never masquerades as
+    // an empty response to session/prompt.
+    if (message.method === "session/update") {
+      this.handleUpdate(message.params);
+      return;
+    }
+    if (message.method === "session/request_permission") {
+      this.handleApproval(message);
+      return;
+    }
     if (message.id !== undefined && this.pendingRequests.has(message.id)) {
       const pending = this.pendingRequests.get(message.id)!;
       this.pendingRequests.delete(message.id);
       if (message.error) pending.reject(new Error(message.error.message)); else pending.resolve(message.result);
-      return;
     }
-    if (message.method === "session/update") this.handleUpdate(message.params);
-    if (message.method === "session/request_permission") this.handleApproval(message);
   }
 
   private handleUpdate(params: any): void {

--- a/node/agent_sdk/acp-protocol.ts
+++ b/node/agent_sdk/acp-protocol.ts
@@ -1,7 +1,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
 
 import type { ApprovalResponse, ContentPart, InitializeResult, RunResult, StreamEvent } from "./schema";
-import { TransportError } from "./errors";
+import { ProtocolError, TransportError } from "./errors";
 import { createEventChannel, type ClientOptions, type PromptStream } from "./protocol";
 
 const ACP_PROTOCOL_VERSION = 1;
@@ -32,6 +32,16 @@ export interface AcpSessionConfig {
     currentValue?: string;
     options?: Array<{ value: string; name: string }>;
   }>;
+}
+
+type AcpSessionResult = Omit<AcpSessionConfig, "sessionId"> & { sessionId?: string };
+
+function toAcpSessionId(sessionId: string): string {
+  return sessionId.startsWith("session_") ? sessionId : `session_${sessionId}`;
+}
+
+function toStorageSessionId(sessionId: string): string {
+  return sessionId.startsWith("session_") ? sessionId.slice("session_".length) : sessionId;
 }
 
 export class AcpProtocolClient {
@@ -78,9 +88,18 @@ export class AcpProtocolClient {
       protocolVersion: ACP_PROTOCOL_VERSION,
       clientCapabilities: {},
     })) as { agentInfo?: { name?: string; version?: string } };
-    const session = (await this.request("session/new", { cwd: options.workDir, mcpServers: [] })) as AcpSessionConfig;
-    this.sessionId = session.sessionId;
-    this.config = session;
+    const session = (await this.request(
+      options.resumeSession && options.sessionId ? "session/load" : "session/new",
+      options.resumeSession && options.sessionId
+        ? { sessionId: toAcpSessionId(options.sessionId), cwd: options.workDir, mcpServers: [] }
+        : { cwd: options.workDir, mcpServers: [] },
+    )) as AcpSessionResult;
+    const acpSessionId = options.resumeSession && options.sessionId ? toAcpSessionId(options.sessionId) : session.sessionId;
+    if (!acpSessionId) {
+      throw new ProtocolError("SCHEMA_MISMATCH", "ACP did not return a session ID");
+    }
+    this.sessionId = acpSessionId;
+    this.config = { sessionId: toStorageSessionId(acpSessionId), configOptions: session.configOptions ?? [] };
     await this.applySessionOptions(options);
 
     return {

--- a/node/agent_sdk/acp-protocol.ts
+++ b/node/agent_sdk/acp-protocol.ts
@@ -94,6 +94,9 @@ export class AcpProtocolClient {
     const channel = createEventChannel<StreamEvent>();
     this.eventChannel = channel;
     channel.push({ type: "TurnBegin", payload: { user_input: content } });
+    // The webview's Wire-compatible renderer requires a step before it can append
+    // text, thoughts, or tool calls from ACP session updates.
+    channel.push({ type: "StepBegin", payload: { n: 1 } });
     const prompt = typeof content === "string" ? [{ type: "text", text: content }] : content.filter((part) => part.type === "text").map((part) => ({ type: "text", text: part.text }));
     const result = this.request("session/prompt", { sessionId: this.sessionId, prompt })
       .then((): RunResult => ({ status: "finished" }))

--- a/node/agent_sdk/acp-protocol.ts
+++ b/node/agent_sdk/acp-protocol.ts
@@ -122,7 +122,7 @@ export class AcpProtocolClient {
     channel.push({ type: "StepBegin", payload: { n: 1 } });
     const prompt = typeof content === "string" ? [{ type: "text", text: content }] : content.filter((part) => part.type === "text").map((part) => ({ type: "text", text: part.text }));
     const result = this.request("session/prompt", { sessionId: this.sessionId, prompt })
-      .then((response): RunResult => this.toRunResult(response as AcpPromptResponse))
+      .then((response): RunResult => this.toRunResult(response as AcpPromptResponse | undefined))
       .finally(() => {
         channel.push({ type: "TurnEnd", payload: {} });
         this.finishEvents();
@@ -200,8 +200,11 @@ export class AcpProtocolClient {
     this.eventChannel?.push({ type: "ApprovalRequest", payload: { id: requestId, tool_call_id: params?.toolCall?.toolCallId ?? "acp", sender: params?.toolCall?.title ?? "Tool", action: "execute tool", description: params?.toolCall?.title ?? "Approval required" } });
   }
 
-  private toRunResult(response: AcpPromptResponse): RunResult {
-    const stopReason = response.stopReason;
+  private toRunResult(response: AcpPromptResponse | undefined): RunResult {
+    // Older Kimi Code ACP builds may acknowledge session/prompt with an
+    // omitted result. Treat that as an unknown terminal reason instead of
+    // dereferencing it and masking the actual unfinished-turn diagnostic.
+    const stopReason = response?.stopReason;
     const pendingToolCallIds = [...this.toolCalls.values()]
       .filter((tool) => tool.status !== "completed" && tool.status !== "failed")
       .map((tool) => tool.toolCallId);

--- a/node/agent_sdk/errors.ts
+++ b/node/agent_sdk/errors.ts
@@ -21,6 +21,7 @@ export const ProtocolErrorCodes = {
   UNKNOWN_REQUEST_TYPE: "UNKNOWN_REQUEST_TYPE",
   REQUEST_TIMEOUT: "REQUEST_TIMEOUT",
   REQUEST_CANCELLED: "REQUEST_CANCELLED",
+  INCOMPLETE_TURN: "INCOMPLETE_TURN",
 } as const;
 
 export const SessionErrorCodes = {

--- a/node/agent_sdk/protocol.ts
+++ b/node/agent_sdk/protocol.ts
@@ -1,5 +1,5 @@
 // agent_sdk/protocol.ts
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { createInterface, type Interface as ReadlineInterface } from "node:readline";
 import {
   parseEventPayload,
@@ -23,6 +23,7 @@ import {
 } from "./schema";
 import { TransportError, ProtocolError, CliError } from "./errors";
 import { log } from "./logger";
+import { AcpProtocolClient, type AcpSessionConfig } from "./acp-protocol";
 
 const PROTOCOL_VERSION = "1.7";
 const SDK_NAME = "kimi-agent-sdk";
@@ -130,6 +131,7 @@ export function createEventChannel<T>(): {
 }
 
 export class ProtocolClient {
+  private acpClient: AcpProtocolClient | null = null;
   private process: ChildProcess | null = null;
   private readline: ReadlineInterface | null = null;
   private requestId = 0;
@@ -142,16 +144,26 @@ export class ProtocolClient {
   private hookHandlers = new Map<string, HookHandler>();
 
   get isRunning(): boolean {
-    return this.process !== null && this.process.exitCode === null;
+    return this.acpClient?.isRunning ?? (this.process !== null && this.process.exitCode === null);
+  }
+
+  get acpSessionConfig(): AcpSessionConfig | null {
+    return this.acpClient?.sessionConfig ?? null;
   }
 
   async start(options: ClientOptions): Promise<InitializeResult> {
-    if (this.process) {
+    if (this.process || this.acpClient) {
       throw new TransportError("ALREADY_STARTED", "Client already started");
     }
 
-    const args = this.buildArgs(options);
     const executable = options.executablePath ?? "kimi";
+
+    if (supportsAcp(executable, options.workDir, options.environmentVariables)) {
+      this.acpClient = new AcpProtocolClient();
+      return this.acpClient.start(options);
+    }
+
+    const args = this.buildArgs(options);
 
     log.protocol("Spawning CLI: %s %o", executable, args);
 
@@ -202,6 +214,11 @@ export class ProtocolClient {
   }
 
   async stop(): Promise<void> {
+    if (this.acpClient) {
+      await this.acpClient.stop();
+      this.acpClient = null;
+      return;
+    }
     if (!this.process) {
       return;
     }
@@ -230,6 +247,9 @@ export class ProtocolClient {
   }
 
   sendPrompt(content: string | ContentPart[]): PromptStream {
+    if (this.acpClient) {
+      return this.acpClient.sendPrompt(content);
+    }
     const { iterable, push, finish } = createEventChannel<StreamEvent>();
 
     this.pushEvent = push;
@@ -254,6 +274,9 @@ export class ProtocolClient {
   }
 
   sendCancel(): Promise<void> {
+    if (this.acpClient) {
+      return this.acpClient.sendCancel();
+    }
     return this.sendRequest("cancel").then(() => {});
   }
 
@@ -285,6 +308,9 @@ export class ProtocolClient {
   }
 
   sendApproval(requestId: string, response: ApprovalResponse): Promise<void> {
+    if (this.acpClient) {
+      return this.acpClient.sendApproval(requestId, response);
+    }
     this.writeLine({
       jsonrpc: "2.0",
       id: requestId,
@@ -627,5 +653,28 @@ export class ProtocolClient {
     this.finishEvents = null;
     this.pendingRequests.clear();
     this.externalToolHandlers.clear();
+  }
+}
+
+const acpSupportCache = new Map<string, boolean>();
+
+function supportsAcp(executable: string, cwd: string, environmentVariables?: Record<string, string>): boolean {
+  const cacheKey = executable;
+  const cached = acpSupportCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+
+  try {
+    const result = spawnSync(executable, ["acp", "--help"], {
+      cwd,
+      env: { ...process.env, ...environmentVariables },
+      stdio: "ignore",
+      timeout: 5000,
+    });
+    const supported = result.status === 0;
+    acpSupportCache.set(cacheKey, supported);
+    return supported;
+  } catch {
+    acpSupportCache.set(cacheKey, false);
+    return false;
   }
 }

--- a/node/agent_sdk/protocol.ts
+++ b/node/agent_sdk/protocol.ts
@@ -55,6 +55,8 @@ export interface HookRegistration {
 
 export interface ClientOptions {
   sessionId?: string;
+  /** Resume an existing session instead of creating a new one when ACP is used. */
+  resumeSession?: boolean;
   workDir: string;
   model?: string;
   thinking?: boolean;

--- a/node/agent_sdk/schema.ts
+++ b/node/agent_sdk/schema.ts
@@ -203,8 +203,12 @@ export type ToolCall = z.infer<typeof ToolCallSchema>;
 
 // Tool call argument chunk (streaming)
 export const ToolCallPartSchema = z.object({
-  // Argument chunk, appended to the last ToolCall's arguments
+  // Argument chunk, appended to the associated ToolCall's arguments
   arguments_part: z.string().nullable().optional(),
+  // Optional tool ID for protocols that stream multiple calls concurrently
+  tool_call_id: z.string().optional(),
+  // Replaces the accumulated arguments instead of appending a delta
+  replace_arguments: z.boolean().optional(),
 });
 export type ToolCallPart = z.infer<typeof ToolCallPartSchema>;
 

--- a/node/agent_sdk/session.ts
+++ b/node/agent_sdk/session.ts
@@ -59,6 +59,8 @@ export interface Session {
   readonly planMode: boolean;
   /** Toggle plan mode on/off */
   setPlanMode(enabled: boolean): Promise<boolean>;
+  /** Initialize the backing protocol and resolve the persistent session ID. */
+  initialize(): Promise<void>;
   /** Send a message, returns a Turn object */
   prompt(content: string | ContentPart[]): Turn;
   /** Close the session, release resources */
@@ -152,7 +154,8 @@ class TurnImpl implements Turn {
 }
 
 class SessionImpl implements Session {
-  private readonly _sessionId: string;
+  private _sessionId: string;
+  private resumeSession: boolean;
   private readonly _workDir: string;
   private readonly _clientInfo?: ClientInfo;
 
@@ -177,6 +180,7 @@ class SessionImpl implements Session {
 
   constructor(options: SessionOptions) {
     this._sessionId = options.sessionId ?? crypto.randomUUID();
+    this.resumeSession = options.sessionId !== undefined;
     this._workDir = options.workDir;
     this._model = options.model;
     this._thinking = options.thinking ?? false;
@@ -256,6 +260,13 @@ class SessionImpl implements Session {
     return this._planMode;
   }
 
+  async initialize(): Promise<void> {
+    if (this._state === "closed") {
+      throw new SessionError("SESSION_CLOSED", "Cannot initialize a closed session");
+    }
+    await this.getClientWithConfigCheck();
+  }
+
   prompt(content: string | ContentPart[]): Turn {
     if (this._state === "closed") {
       throw new SessionError("SESSION_CLOSED", "Session is closed");
@@ -331,6 +342,7 @@ class SessionImpl implements Session {
     const envVars = this._shareDir ? { KIMI_SHARE_DIR: this._shareDir, ...this._env } : this._env;
     const initResult = await this.client.start({
       sessionId: this._sessionId,
+      resumeSession: this.resumeSession,
       workDir: this._workDir,
       model: this._model,
       thinking: this._thinking,
@@ -342,6 +354,12 @@ class SessionImpl implements Session {
       skillsDir: this._skillsDir,
       clientInfo: this._clientInfo,
     });
+
+    const acpSessionId = this.client.acpSessionConfig?.sessionId;
+    if (acpSessionId) {
+      this._sessionId = acpSessionId;
+      this.resumeSession = true;
+    }
 
     this._slashCommands = initResult.slash_commands;
     this.activeConfig = currentConfig;

--- a/node/agent_sdk/tests/protocol.test.ts
+++ b/node/agent_sdk/tests/protocol.test.ts
@@ -340,6 +340,31 @@ describe("ProtocolClient", () => {
   });
 
   describe("ACP prompts", () => {
+    it("loads a persisted session when asked to resume", async () => {
+      const proc = createMockProcess();
+      const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+      proc.stdin.write.mockImplementation((line: string) => {
+        const request = JSON.parse(line);
+        requests.push(request);
+        if (request.method === "initialize") {
+          proc.stdout.push(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: {} })}\n`);
+        } else if (request.method === "session/load") {
+          proc.stdout.push(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { configOptions: [] } })}\n`);
+        }
+        return true;
+      });
+      mockSpawn.mockReturnValue(proc);
+
+      const client = new AcpProtocolClient();
+      await client.start({ workDir: "/tmp", executablePath: "kimi", sessionId: "12345678-1234-1234-1234-123456789abc", resumeSession: true });
+
+      expect(requests).toContainEqual(expect.objectContaining({
+        method: "session/load",
+        params: { sessionId: "session_12345678-1234-1234-1234-123456789abc", cwd: "/tmp", mcpServers: [] },
+      }));
+      expect(client.sessionConfig?.sessionId).toBe("12345678-1234-1234-1234-123456789abc");
+    });
+
     it("emits a step before ACP content updates", async () => {
       const proc = createMockProcess();
       proc.stdin.write.mockImplementation((line: string) => {

--- a/node/agent_sdk/tests/protocol.test.ts
+++ b/node/agent_sdk/tests/protocol.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from "vite
 import { EventEmitter } from "node:events";
 import { Readable } from "node:stream";
 import { createEventChannel } from "../protocol";
-import { mapAcpUpdate } from "../acp-protocol";
+import { AcpProtocolClient, mapAcpUpdate } from "../acp-protocol";
 import { TransportError } from "../errors";
 
 // ============================================================================
@@ -336,6 +336,41 @@ describe("ProtocolClient", () => {
 
       const client = new ProtocolClient();
       await expect(client.start({ sessionId: "test", workDir: "/tmp" })).rejects.toThrow(TransportError);
+    });
+  });
+
+  describe("ACP prompts", () => {
+    it("emits a step before ACP content updates", async () => {
+      const proc = createMockProcess();
+      proc.stdin.write.mockImplementation((line: string) => {
+        const request = JSON.parse(line);
+        if (request.method === "initialize") {
+          proc.stdout.push(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { agentInfo: { name: "Kimi", version: "test" } } })}\n`);
+        } else if (request.method === "session/new") {
+          proc.stdout.push(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { sessionId: "session-1", configOptions: [] } })}\n`);
+        } else if (request.method === "session/prompt") {
+          proc.stdout.push(`${JSON.stringify({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "agent_message_chunk", content: { text: "hello" } } } })}\n`);
+          proc.stdout.push(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: {} })}\n`);
+        }
+        return true;
+      });
+      mockSpawn.mockReturnValue(proc);
+
+      const client = new AcpProtocolClient();
+      await client.start({ workDir: "/tmp", executablePath: "kimi" });
+
+      const stream = client.sendPrompt("Hi");
+      const events = [];
+      for await (const event of stream.events) {
+        events.push(event);
+      }
+
+      expect(events).toEqual([
+        { type: "TurnBegin", payload: { user_input: "Hi" } },
+        { type: "StepBegin", payload: { n: 1 } },
+        { type: "ContentPart", payload: { type: "text", text: "hello" } },
+        { type: "TurnEnd", payload: {} },
+      ]);
     });
   });
 

--- a/node/agent_sdk/tests/protocol.test.ts
+++ b/node/agent_sdk/tests/protocol.test.ts
@@ -397,6 +397,53 @@ describe("ProtocolClient", () => {
         { type: "TurnEnd", payload: {} },
       ]);
     });
+
+    it("preserves a cancelled ACP prompt result", async () => {
+      const proc = createMockProcess();
+      proc.stdin.write.mockImplementation((line: string) => {
+        const request = JSON.parse(line);
+        if (request.method === "initialize") {
+          proc.stdout.push(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: {} })}\n`);
+        } else if (request.method === "session/new") {
+          proc.stdout.push(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { sessionId: "session-1", configOptions: [] } })}\n`);
+        } else if (request.method === "session/prompt") {
+          proc.stdout.push(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { stopReason: "cancelled" } })}\n`);
+        }
+        return true;
+      });
+      mockSpawn.mockReturnValue(proc);
+
+      const client = new AcpProtocolClient();
+      await client.start({ workDir: "/tmp", executablePath: "kimi" });
+      const stream = client.sendPrompt("Hi");
+      await Array.fromAsync(stream.events);
+
+      await expect(stream.result).resolves.toEqual({ status: "cancelled" });
+    });
+
+    it("rejects a completed ACP prompt with unresolved tool calls", async () => {
+      const proc = createMockProcess();
+      proc.stdin.write.mockImplementation((line: string) => {
+        const request = JSON.parse(line);
+        if (request.method === "initialize") {
+          proc.stdout.push(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: {} })}\n`);
+        } else if (request.method === "session/new") {
+          proc.stdout.push(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { sessionId: "session-1", configOptions: [] } })}\n`);
+        } else if (request.method === "session/prompt") {
+          proc.stdout.push(`${JSON.stringify({ jsonrpc: "2.0", method: "session/update", params: { update: { sessionUpdate: "tool_call", toolCallId: "tool-1", title: "Read" } } })}\n`);
+          proc.stdout.push(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { stopReason: "end_turn" } })}\n`);
+        }
+        return true;
+      });
+      mockSpawn.mockReturnValue(proc);
+
+      const client = new AcpProtocolClient();
+      await client.start({ workDir: "/tmp", executablePath: "kimi" });
+      const stream = client.sendPrompt("Hi");
+      await Array.fromAsync(stream.events);
+
+      await expect(stream.result).rejects.toMatchObject({ code: "INCOMPLETE_TURN" });
+    });
   });
 
   describe("stop", () => {

--- a/node/agent_sdk/tests/protocol.test.ts
+++ b/node/agent_sdk/tests/protocol.test.ts
@@ -469,6 +469,37 @@ describe("ProtocolClient", () => {
     });
   });
 
+  it("uses ACP content for streamed tool arguments and results", () => {
+    const tools = new Map();
+    expect(mapAcpUpdate({
+      sessionUpdate: "tool_call",
+      toolCallId: "call-1",
+      title: "Read",
+      content: [{ type: "content", content: { type: "text", text: '{"path":"a.ts"}' } }],
+    }, tools)).toMatchObject([{
+      type: "ToolCall",
+      payload: { function: { arguments: '{"path":"a.ts"}' } },
+    }]);
+    expect(mapAcpUpdate({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "call-1",
+      status: "in_progress",
+      rawInput: { path: "src/a.ts" },
+    }, tools)).toContainEqual({
+      type: "ToolCallPart",
+      payload: { tool_call_id: "call-1", arguments_part: '{"path":"src/a.ts"}', replace_arguments: true },
+    });
+    expect(mapAcpUpdate({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "call-1",
+      status: "completed",
+      content: [{ type: "content", content: { type: "text", text: "file contents" } }],
+    }, tools)).toMatchObject([{
+      type: "ToolResult",
+      payload: { return_value: { output: "file contents" } },
+    }]);
+  });
+
   describe("stop", () => {
     it("does nothing when not started", async () => {
       const client = new ProtocolClient();

--- a/node/agent_sdk/tests/protocol.test.ts
+++ b/node/agent_sdk/tests/protocol.test.ts
@@ -421,6 +421,37 @@ describe("ProtocolClient", () => {
       await expect(stream.result).resolves.toEqual({ status: "cancelled" });
     });
 
+    it("does not confuse a reverse permission request with a prompt response sharing its ID", async () => {
+      const proc = createMockProcess();
+      proc.stdin.write.mockImplementation((line: string) => {
+        const request = JSON.parse(line);
+        if (request.method === "initialize") {
+          proc.stdout.push(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: {} })}\n`);
+        } else if (request.method === "session/new") {
+          proc.stdout.push(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { sessionId: "session-1", configOptions: [] } })}\n`);
+        }
+        return true;
+      });
+      mockSpawn.mockReturnValue(proc);
+
+      const client = new AcpProtocolClient();
+      await client.start({ workDir: "/tmp", executablePath: "kimi" });
+      const stream = client.sendPrompt("Hi");
+      const promptRequest = JSON.parse(proc.stdin.write.mock.calls.at(-1)![0]);
+
+      proc.stdout.push(`${JSON.stringify({
+        jsonrpc: "2.0",
+        id: promptRequest.id,
+        method: "session/request_permission",
+        params: { toolCall: { toolCallId: "tool-1", title: "Bash" }, options: [] },
+      })}\n`);
+      proc.stdout.push(`${JSON.stringify({ jsonrpc: "2.0", id: promptRequest.id, result: { stopReason: "end_turn" } })}\n`);
+
+      const events = await Array.fromAsync(stream.events);
+      expect(events).toContainEqual(expect.objectContaining({ type: "ApprovalRequest" }));
+      await expect(stream.result).resolves.toEqual({ status: "finished" });
+    });
+
     it("tolerates an ACP prompt response with no result payload", async () => {
       const proc = createMockProcess();
       proc.stdin.write.mockImplementation((line: string) => {

--- a/node/agent_sdk/tests/protocol.test.ts
+++ b/node/agent_sdk/tests/protocol.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from "vite
 import { EventEmitter } from "node:events";
 import { Readable } from "node:stream";
 import { createEventChannel } from "../protocol";
+import { mapAcpUpdate } from "../acp-protocol";
 import { TransportError } from "../errors";
 
 // ============================================================================
@@ -107,12 +108,48 @@ describe("createEventChannel", () => {
   });
 });
 
+describe("mapAcpUpdate", () => {
+  it("maps ACP message and thought chunks to content parts", () => {
+    expect(mapAcpUpdate({ sessionUpdate: "agent_message_chunk", content: { text: "hello" } })).toEqual([
+      { type: "ContentPart", payload: { type: "text", text: "hello" } },
+    ]);
+    expect(mapAcpUpdate({ sessionUpdate: "agent_thought_chunk", content: { text: "reasoning" } })).toEqual([
+      { type: "ContentPart", payload: { type: "think", think: "reasoning" } },
+    ]);
+  });
+
+  it("maps ACP tool lifecycle updates to Wire-compatible events", () => {
+    const tools = new Map();
+    expect(mapAcpUpdate({ sessionUpdate: "tool_call", toolCallId: "call-1", title: "Read", rawInput: { path: "a.ts" } }, tools)).toEqual([
+      {
+        type: "ToolCall",
+        payload: {
+          type: "function",
+          id: "call-1",
+          function: { name: "Read", arguments: '{"path":"a.ts"}' },
+          extras: { title: "Read", kind: undefined, status: undefined },
+        },
+      },
+    ]);
+    expect(mapAcpUpdate({ sessionUpdate: "tool_call_update", toolCallId: "call-1", status: "completed", content: "done" }, tools)).toEqual([
+      {
+        type: "ToolResult",
+        payload: {
+          tool_call_id: "call-1",
+          return_value: { is_error: false, output: "done", message: "Tool call completed", display: [] },
+        },
+      },
+    ]);
+  });
+});
+
 // ============================================================================
 // ProtocolClient Tests
 // ============================================================================
 const mockSpawn = vi.fn();
 vi.mock("node:child_process", () => ({
   spawn: (...args: unknown[]) => mockSpawn(...args),
+  spawnSync: () => ({ status: 1 }),
 }));
 
 let ProtocolClient: (typeof import("../protocol"))["ProtocolClient"];

--- a/node/agent_sdk/tests/protocol.test.ts
+++ b/node/agent_sdk/tests/protocol.test.ts
@@ -421,6 +421,29 @@ describe("ProtocolClient", () => {
       await expect(stream.result).resolves.toEqual({ status: "cancelled" });
     });
 
+    it("tolerates an ACP prompt response with no result payload", async () => {
+      const proc = createMockProcess();
+      proc.stdin.write.mockImplementation((line: string) => {
+        const request = JSON.parse(line);
+        if (request.method === "initialize") {
+          proc.stdout.push(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: {} })}\n`);
+        } else if (request.method === "session/new") {
+          proc.stdout.push(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { sessionId: "session-1", configOptions: [] } })}\n`);
+        } else if (request.method === "session/prompt") {
+          proc.stdout.push(`${JSON.stringify({ jsonrpc: "2.0", id: request.id })}\n`);
+        }
+        return true;
+      });
+      mockSpawn.mockReturnValue(proc);
+
+      const client = new AcpProtocolClient();
+      await client.start({ workDir: "/tmp", executablePath: "kimi" });
+      const stream = client.sendPrompt("Hi");
+      await Array.fromAsync(stream.events);
+
+      await expect(stream.result).resolves.toEqual({ status: "finished" });
+    });
+
     it("rejects a completed ACP prompt with unresolved tool calls", async () => {
       const proc = createMockProcess();
       proc.stdin.write.mockImplementation((line: string) => {

--- a/node/agent_sdk/tests/protocol.test.ts
+++ b/node/agent_sdk/tests/protocol.test.ts
@@ -365,6 +365,65 @@ describe("ProtocolClient", () => {
       expect(client.sessionConfig?.sessionId).toBe("12345678-1234-1234-1234-123456789abc");
     });
 
+    it("parses slash commands from the ACP initialize response", async () => {
+      const proc = createMockProcess();
+      proc.stdin.write.mockImplementation((line: string) => {
+        const request = JSON.parse(line);
+        if (request.method === "initialize") {
+          proc.stdout.push(`${JSON.stringify({
+            jsonrpc: "2.0",
+            id: request.id,
+            result: {
+              agentInfo: { name: "Kimi", version: "test" },
+              slashCommands: [
+                { name: "commit", description: "Generate a commit message", aliases: ["c"] },
+                { name: "test", description: "Run tests", aliases: [] },
+                { name: "invalid", aliases: [] },
+              ],
+            },
+          })}\n`);
+        } else if (request.method === "session/new") {
+          proc.stdout.push(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { sessionId: "session-1", configOptions: [] } })}\n`);
+        }
+        return true;
+      });
+      mockSpawn.mockReturnValue(proc);
+
+      const client = new AcpProtocolClient();
+      const initResult = await client.start({ workDir: "/tmp", executablePath: "kimi" });
+
+      expect(initResult.slash_commands).toEqual([
+        { name: "commit", description: "Generate a commit message", aliases: ["c"] },
+        { name: "test", description: "Run tests", aliases: [] },
+      ]);
+    });
+
+    it("falls back to snake_case slash_commands in the ACP initialize response", async () => {
+      const proc = createMockProcess();
+      proc.stdin.write.mockImplementation((line: string) => {
+        const request = JSON.parse(line);
+        if (request.method === "initialize") {
+          proc.stdout.push(`${JSON.stringify({
+            jsonrpc: "2.0",
+            id: request.id,
+            result: {
+              agentInfo: { name: "Kimi", version: "test" },
+              slash_commands: [{ name: "fix", description: "Fix code issues", aliases: [] }],
+            },
+          })}\n`);
+        } else if (request.method === "session/new") {
+          proc.stdout.push(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { sessionId: "session-1", configOptions: [] } })}\n`);
+        }
+        return true;
+      });
+      mockSpawn.mockReturnValue(proc);
+
+      const client = new AcpProtocolClient();
+      const initResult = await client.start({ workDir: "/tmp", executablePath: "kimi" });
+
+      expect(initResult.slash_commands).toEqual([{ name: "fix", description: "Fix code issues", aliases: [] }]);
+    });
+
     it("emits a step before ACP content updates", async () => {
       const proc = createMockProcess();
       proc.stdin.write.mockImplementation((line: string) => {

--- a/node/vscode_extension/shared/errors.ts
+++ b/node/vscode_extension/shared/errors.ts
@@ -40,6 +40,7 @@ export const ERROR_MESSAGES: Record<string, string> = {
   [ProtocolErrorCodes.INVALID_REQUEST]: "Invalid request.",
   [ProtocolErrorCodes.INVALID_PARAMS]: "Invalid parameters.",
   [ProtocolErrorCodes.INTERNAL_ERROR]: "Internal error occurred.",
+  [ProtocolErrorCodes.INCOMPLETE_TURN]: "Kimi Code stopped before completing its pending tool calls. Check the Kimi Code output for the ACP stop reason.",
 };
 
 export function classifyError(code: string): ErrorPhase {

--- a/node/vscode_extension/src/bridge-handler.ts
+++ b/node/vscode_extension/src/bridge-handler.ts
@@ -121,7 +121,7 @@ export class BridgeHandler {
     await Promise.all(dirty.map((d) => d.save()));
   }
 
-  private getOrCreateSession(webviewId: string, model: string, thinking: boolean, sessionId?: string): Session {
+  private async getOrCreateSession(webviewId: string, model: string, thinking: boolean, sessionId?: string): Promise<Session> {
     const workDir = this.requireWorkDir(webviewId);
     const cli = getCLIManager();
     const config = parseConfig();

--- a/node/vscode_extension/src/handlers/auth.handler.ts
+++ b/node/vscode_extension/src/handlers/auth.handler.ts
@@ -18,7 +18,7 @@ export const authHandlers: Record<string, Handler<any, any>> = {
   [Methods.CheckLoginStatus]: async (): Promise<LoginStatus> => {
     // Sync context on check
     await updateLoginContext();
-    return { loggedIn: isLoggedIn() };
+    return { loggedIn: getCLIManager().isAcpAuthenticated() || isLoggedIn() };
   },
 
   [Methods.Login]: async (_, ctx): Promise<LoginResult> => {

--- a/node/vscode_extension/src/handlers/chat.handler.ts
+++ b/node/vscode_extension/src/handlers/chat.handler.ts
@@ -159,7 +159,7 @@ const streamChat: Handler<StreamChatParams, { done: boolean }> = async (params, 
     await ctx.saveAllDirty();
   }
 
-  const session = ctx.getOrCreateSession(params.model, params.thinking, params.sessionId);
+  const session = await ctx.getOrCreateSession(params.model, params.thinking, params.sessionId);
   const workDir = ctx.workDir;
   const sessionId = session.sessionId;
 

--- a/node/vscode_extension/src/handlers/config.handler.ts
+++ b/node/vscode_extension/src/handlers/config.handler.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { Methods } from "../../shared/bridge";
 import { VSCodeSettings } from "../config/vscode-settings";
 import { parseConfig, saveDefaultModel } from "@moonshot-ai/kimi-agent-sdk";
+import { getCLIManager } from "../managers";
 import type { SessionConfig, ExtensionConfig } from "../../shared/types";
 import type { KimiConfig } from "@moonshot-ai/kimi-agent-sdk";
 import type { Handler } from "./types";
@@ -21,7 +22,7 @@ const openSettings: Handler<void, { ok: boolean }> = async () => {
 };
 
 const getModels: Handler<void, KimiConfig> = async () => {
-  return parseConfig();
+  return getCLIManager().getAcpConfig() ?? parseConfig();
 };
 
 const showLogs: Handler<void, { ok: boolean }> = async (_, ctx) => {

--- a/node/vscode_extension/src/handlers/types.ts
+++ b/node/vscode_extension/src/handlers/types.ts
@@ -23,7 +23,7 @@ export interface HandlerContext {
   getSessionId: () => string | null;
   getTurn: () => Turn | undefined;
   setTurn: (turn: Turn | null) => void;
-  getOrCreateSession: (model: string, thinking: boolean, sessionId?: string) => Session;
+  getOrCreateSession: (model: string, thinking: boolean, sessionId?: string) => Promise<Session>;
   closeSession: () => Promise<void>;
   saveAllDirty: () => Promise<void>;
   setCustomWorkDir: (workDir: string | null) => void;

--- a/node/vscode_extension/src/managers/cli.manager.ts
+++ b/node/vscode_extension/src/managers/cli.manager.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import * as fs from "fs";
 import { execFile } from "child_process";
 import { promisify } from "util";
-import { ProtocolClient, type InitializeResult } from "@moonshot-ai/kimi-agent-sdk";
+import { ProtocolClient, type InitializeResult, type KimiConfig } from "@moonshot-ai/kimi-agent-sdk";
 import {
   getPlatformKey,
   getPlatformInfo,
@@ -63,6 +63,8 @@ export class CLIManager {
   private extensionBinPath: string;
   private kimiPath: string;
   private uvPath: string;
+  private acpConfig: KimiConfig | null = null;
+  private acpAuthenticated = false;
 
   constructor(private ctx: vscode.ExtensionContext) {
     const globalBin = path.join(ctx.globalStorageUri.fsPath, "bin");
@@ -81,6 +83,14 @@ export class CLIManager {
     const info = getPlatformInfo();
     const filename = installed?.type === "uv" ? info.wrapper : info.exe;
     return path.join(this.kimiPath, filename);
+  }
+
+  getAcpConfig(): KimiConfig | null {
+    return this.acpConfig;
+  }
+
+  isAcpAuthenticated(): boolean {
+    return this.acpAuthenticated;
   }
 
   async checkInstalled(workDir: string): Promise<CLICheckResult> {
@@ -151,24 +161,18 @@ export class CLIManager {
   private async verify(workDir: string, resolved: { isCustomPath: boolean; path: string }): Promise<CLICheckResult> {
     const execPath = this.getExecutablePath();
 
-    let cliVersion: string;
-    let wireVersion: string;
     try {
       const info = await this.getInfo(execPath);
-      cliVersion = info.kimi_cli_version;
-      wireVersion = info.wire_protocol_version;
+      if (compareVersion(info.kimi_cli_version, MIN_CLI_VERSION) < 0) {
+        console.error(`CLI version too low: ${info.kimi_cli_version} < ${MIN_CLI_VERSION}`);
+        return { ok: false, resolved, error: { type: "version_low", message: `CLI ${info.kimi_cli_version} < ${MIN_CLI_VERSION}` } };
+      }
+      if (compareVersion(info.wire_protocol_version, MIN_WIRE_VERSION) < 0) {
+        console.error(`Wire protocol version too low: ${info.wire_protocol_version} < ${MIN_WIRE_VERSION}`);
+        return { ok: false, resolved, error: { type: "version_low", message: `Wire ${info.wire_protocol_version} < ${MIN_WIRE_VERSION}` } };
+      }
     } catch (err) {
-      console.error("Error getting CLI info:", err);
-      return { ok: false, resolved, error: { type: "not_found", message: errorText(err) } };
-    }
-
-    if (compareVersion(cliVersion, MIN_CLI_VERSION) < 0) {
-      console.error(`CLI version too low: ${cliVersion} < ${MIN_CLI_VERSION}`);
-      return { ok: false, resolved, error: { type: "version_low", message: `CLI ${cliVersion} < ${MIN_CLI_VERSION}` } };
-    }
-    if (compareVersion(wireVersion, MIN_WIRE_VERSION) < 0) {
-      console.error(`Wire protocol version too low: ${wireVersion} < ${MIN_WIRE_VERSION}`);
-      return { ok: false, resolved, error: { type: "version_low", message: `Wire ${wireVersion} < ${MIN_WIRE_VERSION}` } };
+      console.log("CLI does not support the legacy info command; trying ACP handshake", err);
     }
 
     try {
@@ -188,9 +192,32 @@ export class CLIManager {
   private async verifyWire(execPath: string, workDir: string): Promise<InitializeResult> {
     const client = new ProtocolClient();
     try {
-      return await client.start({ sessionId: undefined, workDir, executablePath: execPath });
+      const initialized = await client.start({ sessionId: undefined, workDir, executablePath: execPath });
+      const acpConfig = client.acpSessionConfig;
+      if (acpConfig) {
+        this.acpAuthenticated = true;
+        this.acpConfig = toKimiConfig(acpConfig);
+      } else {
+        this.acpAuthenticated = false;
+        this.acpConfig = null;
+      }
+      return initialized;
     } finally {
       await client.stop();
     }
   }
+}
+
+function toKimiConfig(config: NonNullable<ProtocolClient["acpSessionConfig"]>): KimiConfig {
+  const model = config.configOptions.find((option) => option.id === "model");
+  const thinking = config.configOptions.find((option) => option.id === "thinking");
+  return {
+    defaultModel: model?.currentValue ?? null,
+    defaultThinking: thinking?.currentValue === "on",
+    models: (model?.options ?? []).map((option) => ({
+      id: option.value,
+      name: option.name,
+      capabilities: thinking ? ["thinking"] : [],
+    })),
+  };
 }

--- a/node/vscode_extension/webview-ui/src/components/inputarea/InputArea.tsx
+++ b/node/vscode_extension/webview-ui/src/components/inputarea/InputArea.tsx
@@ -35,7 +35,7 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
   const [cursorPos, setCursorPos] = useState(0);
   const [previewMedia, setPreviewMedia] = useState<string | null>(null);
 
-  const { isStreaming, sendMessage, abort, draftMedia, removeDraftMedia, hasProcessingMedia, getMediaInConversation, pendingInput, queue, planMode } = useChatStore();
+  const { isStreaming, isAborting, sendMessage, abort, draftMedia, removeDraftMedia, hasProcessingMedia, getMediaInConversation, pendingInput, queue, planMode } = useChatStore();
   const { currentModel, thinkingEnabled, updateModel, toggleThinking, models, extensionConfig, getCurrentThinkingMode } = useSettingsStore();
 
   const isProcessing = hasProcessingMedia();
@@ -375,7 +375,7 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
                     variant="ghost"
                     size="xs"
                     className="gap-0.5 text-accent-foreground border-0! h-6 px-1.5 min-w-0 max-w-[calc(100%-4rem)]"
-                    disabled={isStreaming || !hasModels}
+                    disabled={isStreaming || isAborting || !hasModels}
                   >
                     <span className="text-xs truncate block">{currentModelConfig?.name || "No models available"}</span>
                     {hasModels && <IconChevronDown className="size-3.5 shrink-0" />}
@@ -394,7 +394,7 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
                 </DropdownMenuContent>
               </DropdownMenu>
 
-              <ThinkingButton mode={thinkingMode} enabled={thinkingEnabled} disabled={isStreaming} onToggle={toggleThinking} />
+              <ThinkingButton mode={thinkingMode} enabled={thinkingEnabled} disabled={isStreaming || isAborting} onToggle={toggleThinking} />
               <PlanModeButton active={planMode} onToggle={handleTogglePlanMode} />
             </div>
 

--- a/node/vscode_extension/webview-ui/src/stores/chat.store.ts
+++ b/node/vscode_extension/webview-ui/src/stores/chat.store.ts
@@ -88,6 +88,7 @@ export interface ChatState {
   sessionId: string | null;
   messages: ChatMessage[];
   isStreaming: boolean;
+  isAborting: boolean;
   isCompacting: boolean;
   handshakeReceived: boolean;
   draftMedia: DraftMediaItem[];
@@ -163,6 +164,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   sessionId: null,
   messages: [],
   isStreaming: false,
+  isAborting: false,
   isCompacting: false,
   handshakeReceived: false,
   draftMedia: [],
@@ -175,7 +177,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   planMode: false,
 
   sendMessage: (text) => {
-    const { draftMedia, isStreaming } = get();
+    const { draftMedia, isStreaming, isAborting } = get();
     const { currentModel } = useSettingsStore.getState();
 
     const readyMedia = draftMedia.filter((m) => m.dataUri).map((m) => m.dataUri!);
@@ -185,8 +187,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
       return;
     }
 
-    // If streaming, enqueue instead of sending
-    if (isStreaming) {
+    // If streaming or still aborting the previous turn, enqueue instead of sending
+    if (isStreaming || isAborting) {
       get().enqueue(content, currentModel);
       set({ draftMedia: [] });
       return;
@@ -208,9 +210,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   retryLastMessage: () => {
-    const { pendingInput, isStreaming } = get();
+    const { pendingInput, isStreaming, isAborting } = get();
 
-    if (isStreaming || !pendingInput) {
+    if (isStreaming || isAborting || !pendingInput) {
       return;
     }
 
@@ -247,8 +249,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
       }),
     );
 
-    // Auto-send next queued item when streaming ends (complete or error)
-    if (event.type === "stream_complete" || event.type === "error") {
+    // Auto-send next queued item when streaming ends (complete, error, or interrupted)
+    if (event.type === "stream_complete" || event.type === "error" || event.type === "StepInterrupted") {
+      set({ isAborting: false });
       const { queue, isStreaming: stillStreaming } = get();
       if (!stillStreaming && queue.length > 0) {
         setTimeout(() => get().sendNextQueued(), 50);
@@ -269,6 +272,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       sessionId,
       messages: [],
       isStreaming: false,
+      isAborting: false,
       isCompacting: false,
       handshakeReceived: false,
       draftMedia: [],
@@ -324,6 +328,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       sessionId: null,
       messages: [],
       isStreaming: false,
+      isAborting: false,
       isCompacting: false,
       handshakeReceived: false,
       draftMedia: [],
@@ -340,7 +345,33 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
   abort: () => {
     clearHandshakeTimer();
-    bridge.abortChat();
+
+    // Optimistically end the streaming UI so the stop button feels responsive.
+    // isAborting stays true until the backend confirms the turn ended, preventing
+    // a new message from starting a conflicting turn while the old one winds down.
+    set(
+      produce((draft: ChatState) => {
+        draft.isStreaming = false;
+        draft.isAborting = true;
+        draft.isCompacting = false;
+        draft.handshakeReceived = false;
+        const lastAssistant = draft.messages.at(-1);
+        if (lastAssistant?.role === "assistant" && lastAssistant.steps) {
+          for (const step of lastAssistant.steps) {
+            for (const item of step.items) {
+              if (item.type === "text" || item.type === "thinking") {
+                item.finished = true;
+              }
+            }
+          }
+        }
+      }),
+    );
+
+    bridge.abortChat().catch((err) => {
+      console.error("Failed to abort chat:", err);
+    });
+
     set({ pendingQuestion: null });
     useApprovalStore.getState().clearRequests();
   },
@@ -440,8 +471,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   sendNextQueued: () => {
-    const { queue, isStreaming } = get();
-    if (isStreaming || queue.length === 0) {
+    const { queue, isStreaming, isAborting } = get();
+    if (isStreaming || isAborting || queue.length === 0) {
       return;
     }
 

--- a/node/vscode_extension/webview-ui/src/stores/event-handlers.ts
+++ b/node/vscode_extension/webview-ui/src/stores/event-handlers.ts
@@ -206,14 +206,14 @@ function applyEventToSteps(steps: UIStep[], event: { type: string; payload: any 
     }
 
     case "ToolCallPart": {
-      const { arguments_part } = event.payload;
+      const { arguments_part, tool_call_id, replace_arguments } = event.payload;
       if (!arguments_part) {
         break;
       }
-      const tool = findLastToolUse();
+      const tool = tool_call_id ? findToolUseItem(steps, tool_call_id) : findLastToolUse();
 
       if (tool) {
-        tool.call.arguments = (tool.call.arguments || "") + arguments_part;
+        tool.call.arguments = replace_arguments ? arguments_part : (tool.call.arguments || "") + arguments_part;
       }
 
       break;


### PR DESCRIPTION
## Summary
- Resolve #203 by supporting the ACP transport exposed by current Kimi Code CLI releases, including `@moonshot-ai/kimi-code@0.23.6`.
- The VS Code extension previously verified and launched the CLI exclusively through the retired Wire interface: `kimi info --json` and `kimi --work-dir <dir> --wire`. Current CLIs no longer expose those commands, so a valid custom CLI path was rejected before a chat session could start.
- Probe `kimi acp --help` once per executable and preserve the Wire transport as the fallback for older CLIs. The new ACP client performs the JSON-RPC initialize/session lifecycle over stdio and adapts ACP updates to the SDK's existing stream event contract.
- Map streamed assistant text, thinking chunks, tool calls, tool completion/failure, permission requests, approvals, cancellation, and session configuration to the existing VS Code integration.
- Apply the selected model, thinking mode when supported, and YOLO/default permission mode using ACP `session/set_config_option` after creating a session.
- Treat a successful ACP handshake as a valid authenticated CLI connection and expose ACP-provided models to the extension configuration handler.

## Root Cause
The extension and TypeScript SDK were coupled to the legacy Wire protocol. When users configured the current Kimi Code executable, the extension first ran `kimi info --json`, then attempted to start it with `--wire`. Kimi Code 0.23.6 exposes `kimi acp` instead; it rejects the legacy entry points even though the executable is correctly installed and authenticated. That protocol mismatch surfaced as an inability to bind the VS Code extension to the new CLI.

## Verification
- `node/agent_sdk`: TypeScript check passed.
- `node/vscode_extension`: TypeScript check passed.
- `node/agent_sdk/tests/protocol.test.ts`: 30 tests passed, including ACP text/thought and tool lifecycle mapping.
- Built the SDK with `tsup` successfully.
- Ran an end-to-end test against the locally installed Kimi Code 0.23.6 executable: ACP was selected automatically, `yoloMode` was applied through `session/set_config_option`, and a streamed `ACP_ADAPTER_OK` response completed successfully.
- Ran a real tool-use prompt against Kimi Code 0.23.6: observed `ToolCall`, status updates, `ToolResult`, and the final streamed response.
- The full SDK suite has 255 passing tests. Three pre-existing `utils.test.ts` failures remain on Windows because tests assert POSIX separators for paths created with Node's Windows `path.join`; this change does not touch that utility.

## Compatibility
- Older Wire-capable Kimi Code CLIs retain the existing Wire path.
- ACP detection is cached per executable to avoid probing for every session.