### PR TITLE
Allow VS Code conversations to run in the background

### DIFF
--- a/node/vscode_extension/src/bridge-handler.ts
+++ b/node/vscode_extension/src/bridge-handler.ts
@@ -17,8 +17,8 @@ interface RpcResult {
 }
 
 export class BridgeHandler {
-  private sessions = new Map<string, Session>();
-  private turns = new Map<string, Turn>();
+  private sessions = new Map<string, Map<string, Session>>();
+  private turns = new Map<string, Map<string, Turn>>();
   private customWorkDirs = new Map<string, string>(); // webviewId -> custom workDir
   private fileManager: FileManager;
 
@@ -59,10 +59,7 @@ export class BridgeHandler {
     } else {
       this.customWorkDirs.delete(webviewId);
     }
-    // Close session when workDir changes
-    this.sessions.get(webviewId)?.close();
-    this.sessions.delete(webviewId);
-    this.turns.delete(webviewId);
+    // Existing sessions keep their own working directory and may continue in the background.
   }
 
   private requireWorkDir(webviewId: string): string {
@@ -92,25 +89,19 @@ export class BridgeHandler {
       fileManager: this.fileManager,
       reloadWebview: () => this.reloadWebview(webviewId),
       showLogs: this.showLogs,
-      getSession: () => this.sessions.get(webviewId),
+      getSession: (sessionId?: string) => this.getSession(webviewId, sessionId),
       getSessionId: () => this.fileManager.getSessionId(webviewId),
-      getTurn: () => this.turns.get(webviewId),
-      setTurn: (turn: Turn | null) => {
+      getTurn: (sessionId?: string) => this.getTurn(webviewId, sessionId),
+      setTurn: (sessionId: string, turn: Turn | null) => {
+        const turns = this.getTurns(webviewId);
         if (turn) {
-          this.turns.set(webviewId, turn);
+          turns.set(sessionId, turn);
         } else {
-          this.turns.delete(webviewId);
+          turns.delete(sessionId);
         }
       },
       getOrCreateSession: (model, thinking, sessionId) => this.getOrCreateSession(webviewId, model, thinking, sessionId),
-      closeSession: async () => {
-        const session = this.sessions.get(webviewId);
-        if (session) {
-          await session.close();
-          this.sessions.delete(webviewId);
-        }
-        this.turns.delete(webviewId);
-      },
+      closeSession: (sessionId?: string) => this.closeSession(webviewId, sessionId),
       saveAllDirty: () => this.saveAllDirty(),
       setCustomWorkDir: (workDir: string | null) => this.setCustomWorkDir(webviewId, workDir),
     };
@@ -143,7 +134,8 @@ export class BridgeHandler {
     const env = VSCodeSettings.environmentVariables;
     const yoloMode = VSCodeSettings.yoloMode;
 
-    const existing = this.sessions.get(webviewId);
+    const sessions = this.getSessions(webviewId);
+    const existing = sessionId ? sessions.get(sessionId) : undefined;
 
     // Check if we need to restart the session
     if (existing) {
@@ -157,14 +149,13 @@ export class BridgeHandler {
 
       if (needsRestart) {
         existing.close();
-        this.sessions.delete(webviewId);
-        this.turns.delete(webviewId);
+        sessions.delete(existing.sessionId);
+        this.getTurns(webviewId).delete(existing.sessionId);
       }
     }
 
-    const current = this.sessions.get(webviewId);
-    if (current) {
-      return current;
+    if (existing && sessions.has(existing.sessionId)) {
+      return existing;
     }
 
     const session = createSession({
@@ -178,13 +169,13 @@ export class BridgeHandler {
       clientInfo: { name: "kimi-code-for-vs-code", version: VSCodeSettings.getExtensionConfig().version },
     });
 
-    this.sessions.set(webviewId, session);
+    sessions.set(session.sessionId, session);
     this.fileManager.setSessionId(webviewId, session.sessionId);
     return session;
   }
 
   disposeView(webviewId: string): void {
-    this.sessions.get(webviewId)?.close();
+    void this.closeSessions(webviewId);
     this.sessions.delete(webviewId);
     this.turns.delete(webviewId);
     this.fileManager.disposeView(webviewId);
@@ -192,10 +183,58 @@ export class BridgeHandler {
 
   async dispose(): Promise<void> {
     this.fileManager.dispose();
-    for (const s of this.sessions.values()) {
-      await s.close();
+    for (const sessions of this.sessions.values()) {
+      for (const session of sessions.values()) {
+        await session.close();
+      }
     }
     this.sessions.clear();
     this.turns.clear();
+  }
+
+  private getSessions(webviewId: string): Map<string, Session> {
+    let sessions = this.sessions.get(webviewId);
+    if (!sessions) {
+      sessions = new Map();
+      this.sessions.set(webviewId, sessions);
+    }
+    return sessions;
+  }
+
+  private getTurns(webviewId: string): Map<string, Turn> {
+    let turns = this.turns.get(webviewId);
+    if (!turns) {
+      turns = new Map();
+      this.turns.set(webviewId, turns);
+    }
+    return turns;
+  }
+
+  private getSession(webviewId: string, sessionId?: string): Session | undefined {
+    const id = sessionId ?? this.fileManager.getSessionId(webviewId);
+    return id ? this.sessions.get(webviewId)?.get(id) : undefined;
+  }
+
+  private getTurn(webviewId: string, sessionId?: string): Turn | undefined {
+    const id = sessionId ?? this.fileManager.getSessionId(webviewId);
+    return id ? this.turns.get(webviewId)?.get(id) : undefined;
+  }
+
+  private async closeSession(webviewId: string, sessionId?: string): Promise<void> {
+    const id = sessionId ?? this.fileManager.getSessionId(webviewId);
+    if (!id) return;
+    const sessions = this.sessions.get(webviewId);
+    const session = sessions?.get(id);
+    if (session) {
+      await session.close();
+      sessions?.delete(id);
+    }
+    this.turns.get(webviewId)?.delete(id);
+  }
+
+  private async closeSessions(webviewId: string): Promise<void> {
+    const sessions = this.sessions.get(webviewId);
+    if (!sessions) return;
+    await Promise.all([...sessions.values()].map((session) => session.close()));
   }
 }

--- a/node/vscode_extension/src/handlers/chat.handler.ts
+++ b/node/vscode_extension/src/handlers/chat.handler.ts
@@ -17,6 +17,10 @@ interface StreamChatParams {
   sessionId?: string;
 }
 
+interface SessionTarget {
+  sessionId?: string;
+}
+
 interface RespondApprovalParams {
   requestId: string;
   response: ApprovalResponse;
@@ -176,7 +180,7 @@ const streamChat: Handler<StreamChatParams, { done: boolean }> = async (params, 
 
   try {
     const turn = session.prompt(contentWithContext);
-    ctx.setTurn(turn);
+    ctx.setTurn(sessionId, turn);
 
     let result: RunResult = { status: "finished" };
 
@@ -231,11 +235,11 @@ const streamChat: Handler<StreamChatParams, { done: boolean }> = async (params, 
     result = await turn.result;
 
     ctx.broadcast(Events.StreamEvent, { type: "stream_complete", result, _sessionId: sessionId }, ctx.webviewId);
-    ctx.setTurn(null);
+    ctx.setTurn(sessionId, null);
 
     return { done: true };
   } catch (err) {
-    ctx.setTurn(null);
+    ctx.setTurn(sessionId, null);
 
     const code = getErrorCode(err);
     const phase = classifyError(code);
@@ -260,23 +264,26 @@ const streamChat: Handler<StreamChatParams, { done: boolean }> = async (params, 
   }
 };
 
-const abortChat: Handler<void, { aborted: boolean }> = async (_, ctx) => {
-  const turn = ctx.getTurn();
+const abortChat: Handler<SessionTarget, { aborted: boolean }> = async (params, ctx) => {
+  const turn = ctx.getTurn(params.sessionId);
   if (turn) {
     await turn.interrupt();
-    ctx.setTurn(null);
+    const sessionId = params.sessionId ?? ctx.getSessionId();
+    if (sessionId) {
+      ctx.setTurn(sessionId, null);
+    }
   }
   return { aborted: true };
 };
 
-const respondApproval: Handler<RespondApprovalParams, { ok: boolean }> = async (params, ctx) => {
-  const turn = ctx.getTurn();
+const respondApproval: Handler<RespondApprovalParams & SessionTarget, { ok: boolean }> = async (params, ctx) => {
+  const turn = ctx.getTurn(params.sessionId);
   turn?.approve(params.requestId, params.response);
   return { ok: true };
 };
 
-const respondQuestion: Handler<RespondQuestionParams, { ok: boolean }> = async (params, ctx) => {
-  const turn = ctx.getTurn();
+const respondQuestion: Handler<RespondQuestionParams & SessionTarget, { ok: boolean }> = async (params, ctx) => {
+  const turn = ctx.getTurn(params.sessionId);
   if (turn) {
     await turn.respondQuestion(params.rpcRequestId, params.questionRequestId, params.answers);
   }
@@ -287,8 +294,8 @@ interface SetPlanModeParams {
   enabled: boolean;
 }
 
-const setPlanMode: Handler<SetPlanModeParams, { ok: boolean; planMode: boolean }> = async (params, ctx) => {
-  const session = ctx.getSession();
+const setPlanMode: Handler<SetPlanModeParams & SessionTarget, { ok: boolean; planMode: boolean }> = async (params, ctx) => {
+  const session = ctx.getSession(params.sessionId);
   if (!session) {
     return { ok: false, planMode: false };
   }
@@ -300,8 +307,8 @@ interface SteerChatParams {
   content: string | ContentPart[];
 }
 
-const steerChat: Handler<SteerChatParams, { ok: boolean }> = async (params, ctx) => {
-  const turn = ctx.getTurn();
+const steerChat: Handler<SteerChatParams & SessionTarget, { ok: boolean }> = async (params, ctx) => {
+  const turn = ctx.getTurn(params.sessionId);
   if (!turn) {
     return { ok: false };
   }
@@ -309,12 +316,12 @@ const steerChat: Handler<SteerChatParams, { ok: boolean }> = async (params, ctx)
   return { ok: true };
 };
 
-const resetSession: Handler<void, { ok: boolean }> = async (_, ctx) => {
-  const session = ctx.getSession();
+const resetSession: Handler<SessionTarget, { ok: boolean }> = async (params, ctx) => {
+  const session = ctx.getSession(params.sessionId);
   if (session) {
     injectedEditorContextSessions.delete(session.sessionId);
   }
-  await ctx.closeSession();
+  await ctx.closeSession(params.sessionId);
   ctx.fileManager.clearTracked(ctx.webviewId);
   return { ok: true };
 };

--- a/node/vscode_extension/src/handlers/types.ts
+++ b/node/vscode_extension/src/handlers/types.ts
@@ -19,12 +19,12 @@ export interface HandlerContext {
   reloadWebview: () => void;
   showLogs: () => void;
 
-  getSession: () => Session | undefined;
+  getSession: (sessionId?: string) => Session | undefined;
   getSessionId: () => string | null;
-  getTurn: () => Turn | undefined;
-  setTurn: (turn: Turn | null) => void;
+  getTurn: (sessionId?: string) => Turn | undefined;
+  setTurn: (sessionId: string, turn: Turn | null) => void;
   getOrCreateSession: (model: string, thinking: boolean, sessionId?: string) => Session;
-  closeSession: () => Promise<void>;
+  closeSession: (sessionId?: string) => Promise<void>;
   saveAllDirty: () => Promise<void>;
   setCustomWorkDir: (workDir: string | null) => void;
 }

--- a/node/vscode_extension/src/managers/file.manager.ts
+++ b/node/vscode_extension/src/managers/file.manager.ts
@@ -83,7 +83,7 @@ export class FileManager {
     return state;
   }
 
-  setSessionId(webviewId: string, sessionId: string): void {
+  setSessionId(webviewId: string, sessionId: string | null): void {
     this.getViewState(webviewId).sessionId = sessionId;
   }
 

--- a/node/vscode_extension/webview-ui/src/App.tsx
+++ b/node/vscode_extension/webview-ui/src/App.tsx
@@ -21,10 +21,16 @@ function MainContent({ onAuthAction }: { onAuthAction: () => void }) {
 
   useEffect(() => {
     return bridge.on(Events.StreamEvent, (event: UIStreamEvent) => {
-      // 只有当前已有 session 时才过滤，确保 session_start 能正常处理
-      if (sessionId && "_sessionId" in event && event._sessionId && event._sessionId !== sessionId) {
-        console.log("Ignored stream event from another session:", event._sessionId);
-        return;
+      if ("_sessionId" in event && event._sessionId) {
+        if (sessionId && event._sessionId !== sessionId) {
+          console.log("Ignored stream event from another session:", event._sessionId);
+          return;
+        }
+        // A blank conversation may only adopt the session that it starts itself.
+        if (!sessionId && event.type !== "session_start") {
+          console.log("Ignored background stream event while starting a conversation:", event._sessionId);
+          return;
+        }
       }
       processEvent(event);
       if (event.type === "error") {

--- a/node/vscode_extension/webview-ui/src/components/Header.tsx
+++ b/node/vscode_extension/webview-ui/src/components/Header.tsx
@@ -3,7 +3,6 @@ import { IconPlus, IconChevronDown, IconInfoCircle } from "@tabler/icons-react";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { StreamingConfirmDialog } from "./StreamingConfirmDialog";
 import { KimiLogo } from "./KimiLogo";
 import { SessionList } from "./SessionList";
 import { useChatStore } from "@/stores";
@@ -12,23 +11,15 @@ import { ChatStatus, TokenInfo } from "./ChatStatus";
 export function Header() {
   const [showSessionList, setShowSessionList] = useState(false);
   const [showSessionInfo, setShowSessionInfo] = useState(false);
-  const [showConfirmNew, setShowConfirmNew] = useState(false);
-  const { startNewConversation, sessionId, messages, isStreaming } = useChatStore();
+  const { startNewConversation, sessionId, messages } = useChatStore();
 
   const handleNewSession = async () => {
-    // If streaming, show confirmation dialog
-    if (isStreaming) {
-      setShowConfirmNew(true);
-      return;
-    }
-    
     await doStartNewSession();
   };
 
   const doStartNewSession = async () => {
     await startNewConversation();
     setShowSessionList(false);
-    setShowConfirmNew(false);
   };
 
   return (
@@ -85,15 +76,6 @@ export function Header() {
           </div>
         </DialogContent>
       </Dialog>
-
-      <StreamingConfirmDialog
-        open={showConfirmNew}
-        onOpenChange={(open) => !open && setShowConfirmNew(false)}
-        title="Start New Conversation?"
-        description="The current conversation is still generating a response. Starting a new one will truncate the output. Are you sure you want to continue?"
-        confirmLabel="New Conversation"
-        onConfirm={doStartNewSession}
-      />
     </header>
   );
 }

--- a/node/vscode_extension/webview-ui/src/components/QueuedMessagesPanel.tsx
+++ b/node/vscode_extension/webview-ui/src/components/QueuedMessagesPanel.tsx
@@ -6,13 +6,13 @@ import { bridge } from "@/services";
 import { Content } from "@/lib/content";
 
 function QueueItem({ id, content, isStreaming, onEdit }: { id: string; content: string | import("@moonshot-ai/kimi-agent-sdk/schema").ContentPart[]; isStreaming: boolean; onEdit: (id: string) => void }) {
-  const { removeFromQueue, moveQueueItemUp, queue } = useChatStore();
+  const { removeFromQueue, moveQueueItemUp, queue, sessionId } = useChatStore();
   const text = Content.getText(content);
   const hasMedia = Content.hasMedia(content);
   const isFirst = queue[0]?.id === id;
 
   const handleSteer = async () => {
-    const result = await bridge.steerChat(content);
+    const result = await bridge.steerChat(content, sessionId ?? undefined);
     if (result.ok) {
       removeFromQueue(id);
     }

--- a/node/vscode_extension/webview-ui/src/components/SessionList.tsx
+++ b/node/vscode_extension/webview-ui/src/components/SessionList.tsx
@@ -78,12 +78,11 @@ function SessionItem({ session, isSelected, onSelect, onDelete, dirLabel }: Sess
 }
 
 export function SessionList({ onClose }: SessionListProps) {
-  const { loadSession, sessionId, startNewConversation, isStreaming } = useChatStore();
+  const { loadSession, sessionId, startNewConversation } = useChatStore();
   const { workspaceRoot, currentWorkDir, setCurrentWorkDir } = useSettingsStore();
   const [searchQuery, setSearchQuery] = useState("");
   const [deleteTarget, setDeleteTarget] = useState<SessionInfo | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
-  const [pendingSession, setPendingSession] = useState<SessionInfo | null>(null);
 
   const { data: kimiSessions = [], loading, mutate } = useRequest(() => bridge.getAllKimiSessions());
 
@@ -110,12 +109,6 @@ export function SessionList({ onClose }: SessionListProps) {
   const handleSelect = async (session: SessionInfo) => {
     console.log("[SessionList] Loading session:", session.id);
     
-    // If streaming, show confirmation dialog
-    if (isStreaming) {
-      setPendingSession(session);
-      return;
-    }
-    
     await doLoadSession(session);
   };
 
@@ -136,12 +129,6 @@ export function SessionList({ onClose }: SessionListProps) {
     } catch (error) {
       console.error("[SessionList] Failed to load session:", error);
     }
-  };
-
-  const handleConfirmSwitch = async () => {
-    if (!pendingSession) return;
-    await doLoadSession(pendingSession);
-    setPendingSession(null);
   };
 
   const handleDelete = async () => {
@@ -205,15 +192,6 @@ export function SessionList({ onClose }: SessionListProps) {
         confirmDisabled={isDeleting}
         cancelDisabled={isDeleting}
         confirmLoading={isDeleting}
-      />
-
-      <StreamingConfirmDialog
-        open={pendingSession !== null}
-        onOpenChange={(open) => !open && setPendingSession(null)}
-        title="Switch Conversation?"
-        description="The current conversation is still generating a response. Switching will truncate the output. Are you sure you want to continue?"
-        confirmLabel="Switch"
-        onConfirm={handleConfirmSwitch}
       />
     </>
   );

--- a/node/vscode_extension/webview-ui/src/components/inputarea/InputArea.tsx
+++ b/node/vscode_extension/webview-ui/src/components/inputarea/InputArea.tsx
@@ -35,7 +35,7 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
   const [cursorPos, setCursorPos] = useState(0);
   const [previewMedia, setPreviewMedia] = useState<string | null>(null);
 
-  const { isStreaming, sendMessage, abort, draftMedia, removeDraftMedia, hasProcessingMedia, getMediaInConversation, pendingInput, queue, planMode } = useChatStore();
+  const { isStreaming, sendMessage, abort, draftMedia, removeDraftMedia, hasProcessingMedia, getMediaInConversation, pendingInput, queue, planMode, sessionId } = useChatStore();
   const { currentModel, thinkingEnabled, updateModel, toggleThinking, models, extensionConfig, getCurrentThinkingMode } = useSettingsStore();
 
   const isProcessing = hasProcessingMedia();
@@ -51,12 +51,12 @@ export function InputArea({ onAuthAction }: InputAreaProps) {
     }
     const newState = !planMode;
     useChatStore.setState({ planMode: newState }); // optimistic
-    bridge.setPlanMode(newState);
+    bridge.setPlanMode(newState, sessionId ?? undefined);
   };
 
   const handleConfirmExitPlanMode = () => {
     useChatStore.setState({ planMode: false });
-    bridge.setPlanMode(false);
+    bridge.setPlanMode(false, sessionId ?? undefined);
     setShowPlanModeConfirm(false);
   };
 

--- a/node/vscode_extension/webview-ui/src/services/bridge.ts
+++ b/node/vscode_extension/webview-ui/src/services/bridge.ts
@@ -172,12 +172,12 @@ class Bridge {
     return this.call<{ done: boolean }>(Methods.StreamChat, { content, model, thinking, sessionId });
   }
 
-  abortChat() {
-    return this.call<{ aborted: boolean }>(Methods.AbortChat);
+  abortChat(sessionId?: string) {
+    return this.call<{ aborted: boolean }>(Methods.AbortChat, { sessionId });
   }
 
-  resetSession() {
-    return this.call<{ ok: boolean }>(Methods.ResetSession);
+  resetSession(sessionId?: string) {
+    return this.call<{ ok: boolean }>(Methods.ResetSession, { sessionId });
   }
 
   getProjectFiles(params?: { query?: string; directory?: string }) {
@@ -192,12 +192,12 @@ class Bridge {
     return this.call<void>(Methods.InsertText, { text });
   }
 
-  respondApproval(requestId: string, response: ApprovalResponse) {
-    return this.call<{ ok: boolean }>(Methods.RespondApproval, { requestId, response });
+  respondApproval(requestId: string, response: ApprovalResponse, sessionId?: string) {
+    return this.call<{ ok: boolean }>(Methods.RespondApproval, { requestId, response, sessionId });
   }
 
-  respondQuestion(rpcRequestId: string, questionRequestId: string, answers: Record<string, string>) {
-    return this.call<{ ok: boolean }>(Methods.RespondQuestion, { rpcRequestId, questionRequestId, answers });
+  respondQuestion(rpcRequestId: string, questionRequestId: string, answers: Record<string, string>, sessionId?: string) {
+    return this.call<{ ok: boolean }>(Methods.RespondQuestion, { rpcRequestId, questionRequestId, answers, sessionId });
   }
 
   getKimiSessions() {
@@ -276,12 +276,12 @@ class Bridge {
     return this.call<string | null>(Methods.GetImageDataUri, { filePath });
   }
 
-  setPlanMode(enabled: boolean) {
-    return this.call<{ ok: boolean; planMode: boolean }>(Methods.SetPlanMode, { enabled });
+  setPlanMode(enabled: boolean, sessionId?: string) {
+    return this.call<{ ok: boolean; planMode: boolean }>(Methods.SetPlanMode, { enabled, sessionId });
   }
 
-  steerChat(content: string | ContentPart[]) {
-    return this.call<{ ok: boolean }>(Methods.SteerChat, { content });
+  steerChat(content: string | ContentPart[], sessionId?: string) {
+    return this.call<{ ok: boolean }>(Methods.SteerChat, { content, sessionId });
   }
 
   showLogs() {

--- a/node/vscode_extension/webview-ui/src/stores/chat.store.ts
+++ b/node/vscode_extension/webview-ui/src/stores/chat.store.ts
@@ -146,7 +146,7 @@ function doSend(state: ChatState, content: string | ContentPart[], model: string
   handshakeTimer = setTimeout(() => {
     const s = useChatStore.getState();
     if (s.isStreaming && !s.handshakeReceived) {
-      bridge.abortChat();
+      bridge.abortChat(s.sessionId ?? undefined);
       s.processEvent({
         type: "error",
         code: "HANDSHAKE_TIMEOUT",
@@ -259,12 +259,6 @@ export const useChatStore = create<ChatState>((set, get) => ({
   loadSession: async (sessionId, events) => {
     clearHandshakeTimer();
     
-    // Abort any ongoing stream when switching sessions
-    const { isStreaming: wasStreaming } = get();
-    if (wasStreaming) {
-      await bridge.abortChat();
-    }
-    
     set({
       sessionId,
       messages: [],
@@ -312,13 +306,6 @@ export const useChatStore = create<ChatState>((set, get) => ({
   startNewConversation: async () => {
     clearHandshakeTimer();
     
-    // Abort any ongoing stream before starting new conversation
-    const { isStreaming: wasStreaming } = get();
-    if (wasStreaming) {
-      bridge.abortChat();
-    }
-    
-    await bridge.resetSession();
     await bridge.clearTrackedFiles();
     set({
       sessionId: null,
@@ -340,7 +327,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
   abort: () => {
     clearHandshakeTimer();
-    bridge.abortChat();
+    bridge.abortChat(get().sessionId ?? undefined);
     set({ pendingQuestion: null });
     useApprovalStore.getState().clearRequests();
   },
@@ -407,7 +394,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   respondQuestion: async (answers) => {
     const { pendingQuestion } = get();
     if (!pendingQuestion) return;
-    await bridge.respondQuestion(pendingQuestion.id, pendingQuestion.id, answers);
+    await bridge.respondQuestion(pendingQuestion.id, pendingQuestion.id, answers, get().sessionId ?? undefined);
     set({ pendingQuestion: null });
   },
 


### PR DESCRIPTION
## Summary
- Allow the VS Code extension to keep an in-progress conversation running after the user starts a new conversation or switches to another history entry.
- Replace the extension host's single `Session` and single `Turn` per webview with session-ID keyed maps. Each active Kimi session now retains its own SDK session, turn, and CLI process.
- Route stop, steering, plan-mode changes, approvals, and question responses to the intended session instead of whichever turn was most recently created.
- Remove the UI confirmation flows that warned that starting or switching conversations would truncate the current response. These actions now change only the visible conversation.
- Preserve event isolation in the webview: background events remain tagged with `_sessionId` and cannot overwrite the currently displayed conversation, including the short interval while a new conversation is blank.
- Do not close running sessions merely because the user changes the working directory for a later conversation; each existing SDK session already owns its original working directory.

## Root Cause
The extension treated a webview as if it could have only one conversation. `BridgeHandler` stored sessions and turns under `webviewId` alone. When `StreamChat` began with another session ID, `getOrCreateSession` closed the previous session and deleted its turn. The webview compounded this by calling `abortChat` and `resetSession` before creating a new conversation or loading history. As a result, clicking the plus button or selecting another session always interrupted the active task instead of allowing it to continue in the background.

## Behavior After This Change
1. Start a long-running task in conversation A.
2. Click the plus button and start conversation B, or open conversation C from History.
3. Conversation A continues running in the extension host while B/C is displayed.
4. Switching back after A finishes shows its persisted history. The stop button, queued-message steering, and question response APIs carry the current session ID, so they do not affect another background conversation.

## Verification
- `node/vscode_extension`: TypeScript check passed.
- `node/vscode_extension/webview-ui`: TypeScript check passed.
- Built the extension host with `esbuild --production` successfully.
- Built the webview production bundle with Vite successfully.
- Ran `git diff --check` successfully.

## Issue Search
- Searched open upstream issues for concurrent/background/parallel/session/interrupt reports.
- No duplicate issue specifically describes background execution being cancelled by new conversation or history navigation.
- Issue #165 concerns session history naming and issue #181 concerns stopping a running task; neither covers concurrent background conversations.