### PR TITLE
Virtualize VS Code chat history to reduce Renderer CPU

### DIFF
--- a/node/vscode_extension/webview-ui/src/components/ChatArea.tsx
+++ b/node/vscode_extension/webview-ui/src/components/ChatArea.tsx
@@ -1,53 +1,142 @@
-import ScrollToBottom, { useScrollToBottom, useSticky } from "react-scroll-to-bottom";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { IconArrowDown } from "@tabler/icons-react";
 import { ChatMessage } from "./ChatMessage";
 import { WelcomeScreen } from "./WelcomeScreen";
-import { useChatStore } from "@/stores";
+import { useChatStore, type ChatMessage as ChatMessageType } from "@/stores";
 import { cn } from "@/lib/utils";
 
-function ScrollButton() {
-  const scrollToBottom = useScrollToBottom();
-  const [sticky] = useSticky();
+const ESTIMATED_MESSAGE_HEIGHT = 240;
+const OVERSCAN_PX = 800;
+const BOTTOM_THRESHOLD_PX = 32;
 
-  if (sticky) return null;
+interface VirtualMessageProps {
+  index: number;
+  message: ChatMessageType;
+  turnIndex?: number;
+  isStreaming: boolean;
+  onHeight: (id: string, height: number) => void;
+}
+
+function VirtualMessage({ index, message, turnIndex, isStreaming, onHeight }: VirtualMessageProps) {
+  const elementRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const element = elementRef.current;
+    if (!element) return;
+
+    const observer = new ResizeObserver(([entry]) => onHeight(message.id, entry.borderBoxSize[0]?.blockSize ?? entry.contentRect.height));
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [message.id, onHeight]);
 
   return (
-    <button
-      onClick={() => scrollToBottom()}
-      className={cn("absolute bottom-4 right-4 p-2 rounded-full z-10", "bg-blue-400 text-white shadow-lg", "hover:bg-blue-600 transition-all")}
-    >
-      <IconArrowDown className="size-4" />
-    </button>
+    <div ref={elementRef} data-message-index={index}>
+      <ChatMessage message={message} turnIndex={turnIndex} isStreaming={isStreaming} />
+    </div>
   );
+}
+
+function findFirstVisible(offsets: number[], target: number): number {
+  let low = 0;
+  let high = offsets.length - 2;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if (offsets[middle + 1] <= target) low = middle + 1;
+    else high = middle;
+  }
+  return low;
 }
 
 function MessageList() {
   const { messages, isStreaming } = useChatStore();
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const heightsRef = useRef(new Map<string, number>());
+  const [measurementVersion, setMeasurementVersion] = useState(0);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewportHeight, setViewportHeight] = useState(0);
+  const [isAtBottom, setIsAtBottom] = useState(true);
 
-  // Calculate turn index for each assistant message
-  // Turn index is 0-indexed, counting user messages
-  const getTurnIndex = (idx: number): number | undefined => {
-    if (messages[idx]?.role !== "assistant") return undefined;
+  const { offsets, turnIndexes, totalHeight } = useMemo(() => {
+    const nextOffsets = [0];
+    const nextTurnIndexes: Array<number | undefined> = [];
     let turnCount = 0;
-    for (let i = 0; i < idx; i++) {
-      if (messages[i].role === "user") turnCount++;
+
+    for (const message of messages) {
+      if (message.role === "user") turnCount++;
+      nextTurnIndexes.push(message.role === "assistant" ? turnCount - 1 : undefined);
+      nextOffsets.push(nextOffsets.at(-1)! + (heightsRef.current.get(message.id) ?? ESTIMATED_MESSAGE_HEIGHT));
     }
-    return turnCount - 1; // 0-indexed (first turn = 0)
-  };
+
+    return { offsets: nextOffsets, turnIndexes: nextTurnIndexes, totalHeight: nextOffsets.at(-1) ?? 0 };
+  }, [messages, measurementVersion]);
+
+  const visibleRange = useMemo(() => {
+    if (messages.length === 0) return { start: 0, end: 0 };
+    const start = findFirstVisible(offsets, Math.max(0, scrollTop - OVERSCAN_PX));
+    const end = Math.min(messages.length, findFirstVisible(offsets, scrollTop + viewportHeight + OVERSCAN_PX) + 1);
+    return { start, end };
+  }, [messages.length, offsets, scrollTop, viewportHeight]);
+
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
+    viewportRef.current?.scrollTo({ top: viewportRef.current.scrollHeight, behavior });
+  }, []);
+
+  const handleHeight = useCallback((id: string, height: number) => {
+    const roundedHeight = Math.ceil(height);
+    if (heightsRef.current.get(id) === roundedHeight) return;
+    heightsRef.current.set(id, roundedHeight);
+    setMeasurementVersion((version) => version + 1);
+  }, []);
+
+  const handleScroll = useCallback(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    setScrollTop(viewport.scrollTop);
+    setIsAtBottom(viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop <= BOTTOM_THRESHOLD_PX);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (isAtBottom) scrollToBottom("auto");
+  }, [isAtBottom, isStreaming, messages, measurementVersion, scrollToBottom]);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    const observer = new ResizeObserver(([entry]) => setViewportHeight(entry.contentRect.height));
+    observer.observe(viewport);
+    setViewportHeight(viewport.clientHeight);
+    return () => observer.disconnect();
+  }, []);
 
   return (
     <>
-      <div className="">
-        {messages.map((message, idx) => (
-          <ChatMessage
-            key={message.id}
-            message={message}
-            turnIndex={getTurnIndex(idx)}
-            isStreaming={isStreaming && idx === messages.length - 1 && message.role === "assistant"}
-          />
-        ))}
+      <div ref={viewportRef} className="h-full overflow-y-auto overflow-x-hidden" onScroll={handleScroll}>
+        <div style={{ height: totalHeight, position: "relative" }}>
+          <div style={{ position: "absolute", top: offsets[visibleRange.start], left: 0, right: 0 }}>
+            {messages.slice(visibleRange.start, visibleRange.end).map((message, relativeIndex) => {
+              const index = visibleRange.start + relativeIndex;
+              return (
+                <VirtualMessage
+                  key={message.id}
+                  index={index}
+                  message={message}
+                  turnIndex={turnIndexes[index]}
+                  isStreaming={isStreaming && index === messages.length - 1 && message.role === "assistant"}
+                  onHeight={handleHeight}
+                />
+              );
+            })}
+          </div>
+        </div>
       </div>
-      <ScrollButton />
+      {!isAtBottom && (
+        <button
+          onClick={() => scrollToBottom()}
+          className={cn("absolute bottom-4 right-4 p-2 rounded-full z-10", "bg-blue-400 text-white shadow-lg", "hover:bg-blue-600 transition-all")}
+        >
+          <IconArrowDown className="size-4" />
+        </button>
+      )}
     </>
   );
 }
@@ -65,9 +154,7 @@ export function ChatArea() {
 
   return (
     <div className="h-full relative">
-      <ScrollToBottom className="h-full" scrollViewClassName="h-full overflow-y-auto overflow-x-hidden" followButtonClassName="hidden" initialScrollBehavior="auto">
-        <MessageList />
-      </ScrollToBottom>
+      <MessageList />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Resolve #156 by virtualizing the VS Code extension chat history.
- Replace the unconditional `messages.map()` rendering path with a measured virtual list that mounts only the messages in and near the viewport.
- Track each rendered message with `ResizeObserver` so variable-height Markdown, thinking blocks, tool calls, diffs, and media retain correct scroll positions without requiring a fixed row height.
- Use a stable estimated height for offscreen messages, render an 800px overscan region to avoid visible pop-in, and update offsets as real measurements arrive.
- Preserve the existing chat ergonomics: follow streamed output while the user is at the bottom, leave the scroll position alone after the user scrolls upward, and show a return-to-bottom button.

## Root Cause
`ChatArea` rendered every entry in the current conversation with `messages.map()`. A long Kimi Code session can contain hundreds of user and assistant messages; each assistant message may also contain deeply nested Markdown, tool output, thinking sections, plans, diffs, and media. Although only the final assistant message changes during streaming, each incoming chunk updates the Zustand store and React reconciles a DOM tree containing the entire conversation.

This matches the #156 performance profile: Renderer CPU remains high even while idle and Pre-paint dominates frame time. The browser must repeatedly walk a large render tree, so the UI can make the system feel sluggish independently of Extension Host or CLI CPU usage.

## Implementation Notes
- `ChatArea` now owns the scroll viewport and calculates cumulative message offsets from cached measured heights.
- Only the range intersecting the viewport plus overscan is passed to `ChatMessage`; old message DOM nodes are removed while their logical chat state remains in the store.
- A binary search finds the visible range, avoiding a linear scan of all messages for every scroll update.
- Auto-follow is conditional on being within 32px of the bottom, avoiding forced scrolling while users inspect history.

## Verification
- `node/vscode_extension/webview-ui`: TypeScript check passed.
- Built the Webview with Vite successfully.
- `git diff --check` passed.
- Confirmed the full-history render path was removed: `ChatArea` now renders `messages.slice(visibleRange.start, visibleRange.end)` instead of rendering every message.
- Production bundle decreased from approximately 6.14 MB to 6.04 MB after the unused scroll component path was eliminated from the bundle.